### PR TITLE
Changing SevenZip class exposed API

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -17,6 +17,16 @@ Added
 Changed
 -------
 
+* Remove print functions from API and moves CLI
+    - API should not output anything other than error message.
+      * Introduce FileInfo class to represent file attributes inside
+      archive.
+      * Introduce ArchiveInfo class to represent archive attributes.
+      * provide archiveinfo() method to provide ArchiveInfo object.
+      * now list() method returns List[FileInfo]
+    - Every print things moves to Cli class.
+* Update tests according to API change.
+
 Fixed
 -----
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Contents:
 
    py7zr
    design
+   internal_classes
    AUTHORS
    glossary
 

--- a/docs/internal_classes.rst
+++ b/docs/internal_classes.rst
@@ -1,0 +1,82 @@
+:tocdepth: 2
+
+.. _internal_classes:
+
+================
+Internal classes
+================
+
+.. _archivefile-objects:
+
+ArchiveFile Objects
+-------------------
+
+Instances of the :class:`ArchiveFile` class are returned by iterating :attr:`files_list` of :class:`SevenZipFile` objects.
+Each object stores information about a single member of the 7z archive. Most of users use :meth:`extractall()`.
+
+Instances have the following methods and attributes:
+
+.. method:: ArchiveFile.get_properties()
+
+   Return file properties as a hash object. Following keys are included:
+   'readonly', 'is_directory', 'posix_mode', 'archivable',
+   'emptystream', 'filename', 'creationtime', 'lastaccesstime', 'lastwritetime',
+   'attributes'
+
+
+.. attribute:: ArchiveFile.posix_mode
+
+   posix mode when a member has a unix extension property, or None
+
+
+.. attribute:: ArchiveFile.id
+
+   Reference identifier number of a member.
+
+
+.. attribute:: ArchiveFile.filename
+
+   Name of the file in the archive.
+
+
+.. attribute:: ArchiveFile.lastwritetime
+
+   Value of lastwritetime property of a member
+
+
+.. attribute:: ArchiveFile.is_directory
+
+   ``True`` if this archive member is a directory.
+
+   This uses the entry's name: directories should always end with ``/``.
+
+
+.. attribute:: ArchiveFile.is_symlink
+
+   ``True`` if this archive member is a symbolic link.
+
+
+.. attribute:: ArchiveFile.archivable
+
+   ``True`` if `Archive` property of a member is enabled, otherwise ``False``.
+
+
+.. attribute:: ArchiveFile.readonly
+
+   ``True`` if `Readonly` property of a member is enabled, otherwise ``False``.
+
+
+.. attribute:: ArchiveFile.emptystream
+
+   ``True`` if a member don't have a data stream, otherwise ``False``.
+
+
+.. attribute:: ArchiveFile.uncompressed_size
+
+   Size of the uncompressed file.
+
+
+.. attribute:: ArchiveFile.uncompressed
+
+   Array data of uncompressed property of a member.
+

--- a/docs/py7zr.rst
+++ b/docs/py7zr.rst
@@ -27,16 +27,19 @@ The module defines the following items:
    :noindex:
 
    The class for reading 7z files.  See section
-   :ref:`sevenzipfile-objects` for constructor details.
+   :ref:`sevenzipfile-object` for constructor details.
 
 
-.. class:: ArchiveFile
+.. class:: ArchiveInfo
 
-   Class used to represent information about a member of an archive. Instances
-   of this class are returned by iteration of :attr:`files_list` of :class:`SevenZipFile` objects.
-   Most users of the :mod:`py7zr` module should not create these, but only use those created by this
-   module.
-   :ref:`archivefile-objects`.
+   Class used to represent information about an information of an archive file.
+   :ref:`archiveinfo-object`.
+
+
+.. class:: FileInfo
+
+    Class used to represent information about a member of an archive file.
+   :ref:`fileinfo-objects`.
 
 
 .. function:: is_7zfile(filename)
@@ -66,10 +69,10 @@ The module defines the following items:
     `shutil`_  :mod:`shutil` module offers a number of high-level operations on files and collections of files.
 
 
-.. _sevenzipfile-objects:
+.. _sevenzipfile-object:
 
-SevenZipFile Objects
---------------------
+SevenZipFile Object
+-------------------
 
 
 .. class:: SevenZipFile(file, mode='r', compressionlevel=None)
@@ -107,7 +110,12 @@ SevenZipFile Objects
 
 .. method:: SevenZipFile.list()
 
-   Print a table of contents for the archive to ``sys.stdout``.
+    Return a List[FileInfo].
+
+
+.. method:: SevenZipFile.archiveinfo()
+
+    Return a ArchiveInfo object.
 
 
 .. method:: SevenZipFile.testzip()
@@ -124,79 +132,22 @@ SevenZipFile Objects
    The archive must be open with mode ``'w'``, ``'x'`` or ``'a'``. [#f5]_
 
 
-.. _archivefile-objects:
+.. _archiveinfo-object:
 
-ArchiveFile Objects
--------------------
+ArchiveInfo Object
+--------------------
 
-Instances of the :class:`ArchiveFile` class are returned by iterating :attr:`files_list` of :class:`SevenZipFile` objects.
-Each object stores information about a single member of the 7z archive. Most of users use :meth:`extractall()`.
-
-Instances have the following methods and attributes:
-
-.. method:: ArchiveFile.get_properties()
-
-   Return file properties as a hash object. Following keys are included:
-   'readonly', 'is_directory', 'posix_mode', 'archivable',
-   'emptystream', 'filename', 'creationtime', 'lastaccesstime', 'lastwritetime',
-   'attributes'
+ArchiveInfo object represent archive information.
 
 
-.. attribute:: ArchiveFile.posix_mode
 
-   posix mode when a member has a unix extension property, or None
+.. _fileinfo-objects:
 
+FileInfo Objects
+--------------------
 
-.. attribute:: ArchiveFile.id
+FileInfo objects represent a file information of member of archive.
 
-   Reference identifier number of a member.
-
-
-.. attribute:: ArchiveFile.filename
-
-   Name of the file in the archive.
-
-
-.. attribute:: ArchiveFile.lastwritetime
-
-   Value of lastwritetime property of a member
-
-
-.. attribute:: ArchiveFile.is_directory
-
-   ``True`` if this archive member is a directory.
-
-   This uses the entry's name: directories should always end with ``/``.
-
-
-.. attribute:: ArchiveFile.is_symlink
-
-   ``True`` if this archive member is a symbolic link.
-
-
-.. attribute:: ArchiveFile.archivable
-
-   ``True`` if `Archive` property of a member is enabled, otherwise ``False``.
-
-
-.. attribute:: ArchiveFile.readonly
-
-   ``True`` if `Readonly` property of a member is enabled, otherwise ``False``.
-
-
-.. attribute:: ArchiveFile.emptystream
-
-   ``True`` if a member don't have a data stream, otherwise ``False``.
-
-
-.. attribute:: ArchiveFile.uncompressed_size
-
-   Size of the uncompressed file.
-
-
-.. attribute:: ArchiveFile.uncompressed
-
-   Array data of uncompressed property of a member.
 
 
 .. _py7zr-commandline:

--- a/py7zr/__init__.py
+++ b/py7zr/__init__.py
@@ -19,7 +19,7 @@
 
 from py7zr.exceptions import (Bad7zFile, DecompressionError,
                               UnsupportedCompressionMethodError)
-from py7zr.py7zr import SevenZipFile, is_7zfile, unpack_7zarchive
+from py7zr.py7zr import ArchiveInfo, FileInfo, SevenZipFile, is_7zfile, unpack_7zarchive
 
 __copyright__ = 'Copyright (C) 2019 Hiroshi Miura'
 __version__ = '0.3.3'

--- a/py7zr/__init__.py
+++ b/py7zr/__init__.py
@@ -19,7 +19,8 @@
 
 from py7zr.exceptions import (Bad7zFile, DecompressionError,
                               UnsupportedCompressionMethodError)
-from py7zr.py7zr import ArchiveInfo, FileInfo, SevenZipFile, is_7zfile, unpack_7zarchive
+from py7zr.py7zr import (ArchiveInfo, FileInfo, SevenZipFile, is_7zfile,
+                         unpack_7zarchive)
 
 __copyright__ = 'Copyright (C) 2019 Hiroshi Miura'
 __version__ = '0.3.3'
@@ -28,5 +29,5 @@ __author__ = 'Hiroshi Miura'
 __author_email__ = 'miurahr@linux.com'
 __url__ = 'http://github.com/miurahr/py7zr'
 
-__all__ = ['SevenZipFile', 'is_7zfile',
+__all__ = ['ArchiveInfo', 'FileInfo', 'SevenZipFile', 'is_7zfile',
            'UnsupportedCompressionMethodError', 'Bad7zFile', 'DecompressionError', 'unpack_7zarchive']

--- a/py7zr/cli.py
+++ b/py7zr/cli.py
@@ -16,18 +16,28 @@
 #    You should have received a copy of the GNU Lesser General Public
 #    License along with this library; if not, write to the Free Software
 #    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-import argparse
-import lzma
-import os
-from typing import Any, Optional
 
+import argparse
+import os
+import sys
+from lzma import CHECK_CRC64, CHECK_SHA256, is_check_supported
+from typing import Any, Optional
 import py7zr
 import texttable  # type: ignore
+
+from py7zr.helpers import Local
 from py7zr.properties import SupportedMethods
 
-
 class Cli():
-    def __init__(self) -> None:
+
+    parser: argparse.ArgumentParser = None
+
+    def run(self, arg: Optional[Any] = None) -> int:
+        self.parser = self._create_parser()
+        args = self.parser.parse_args(arg)
+        return args.func(args)
+
+    def _create_parser(self):
         parser = argparse.ArgumentParser(prog='py7zr', description='py7zr',
                                          formatter_class=argparse.RawTextHelpFormatter, add_help=True)
         subparsers = parser.add_subparsers(title='subcommands', help='subcommand for py7zr l .. list, x .. extract,'
@@ -35,6 +45,7 @@ class Cli():
         list_parser = subparsers.add_parser('l')
         list_parser.set_defaults(func=self.run_list)
         list_parser.add_argument("arcfile", help="7z archive file")
+        list_parser.add_argument("--verbose", action="store_true", help="verbose output")
         extract_parser = subparsers.add_parser('x')
         extract_parser.set_defaults(func=self.run_extract)
         extract_parser.add_argument("arcfile", help="7z archive file")
@@ -49,15 +60,11 @@ class Cli():
         info_parser = subparsers.add_parser("i")
         info_parser.set_defaults(func=self.run_info)
         parser.set_defaults(func=self.show_help)
-        self.parser = parser
+        return parser
 
     def show_help(self, args):
         self.parser.print_help()
         return(0)
-
-    def run(self, arg: Optional[Any] = None) -> int:
-        args = self.parser.parse_args(arg)
-        return args.func(args)
 
     def run_info(self, args):
         print("py7zr version {} {}".format(py7zr.__version__, py7zr.__copyright__))
@@ -82,20 +89,84 @@ class Cli():
         print("\nChecks:")
         print("CHECK_NONE")
         print("CHECK_CRC32")
-        if lzma.is_check_supported(lzma.CHECK_CRC64):
+        if is_check_supported(CHECK_CRC64):
             print("CHECK_CRC64")
-        if lzma.is_check_supported(lzma.CHECK_SHA256):
+        if is_check_supported(CHECK_SHA256):
             print("CHECK_SHA256")
 
     def run_list(self, args):
+        """Print a table of contents to file. """
         target = args.arcfile
+        verbose = args.verbose
         if not py7zr.is_7zfile(target):
             print('not a 7z file')
             return(1)
         with open(target, 'rb') as f:
             a = py7zr.SevenZipFile(f)
-            a.list()
+            file = sys.stdout
+            archive_info = a.archiveinfo()
+            archive_list = a.list()
+            if verbose:
+                file.write("Listing archive: {}\n".format(target))
+                file.write("--\n")
+                file.write("Path = {}\n".format(archive_info.filename))
+                file.write("Type = 7z\n")
+                fstat = os.stat(archive_info.filename)
+                file.write("Phisical Size = {}\n".format(fstat.st_size))
+                file.write("Headers Size = {}\n".format(archive_info.header_size))
+                file.write("Method = {}\n".format(archive_info.method_names))
+                if archive_info.solid:
+                    file.write("Solid = {}\n".format('+'))
+                else:
+                    file.write("Solid = {}\n".format('-'))
+                file.write("Blocks = {}\n".format(archive_info.blocks))
+                file.write('\n')
+            file.write(
+                'total %d files and directories in %sarchive\n' % (len(archive_list),
+                                                                   (archive_info.solid and 'solid ') or ''))
+            file.write('   Date      Time    Attr         Size   Compressed  Name\n')
+            file.write('------------------- ----- ------------ ------------  ------------------------\n')
+            for f in archive_list:
+                if f.creationtime is not None:
+                    creationdate = f.creationtime.astimezone(Local).strftime("%Y-%m-%d")
+                    creationtime = f.creationtime.astimezone(Local).strftime("%H:%M:%S")
+                else:
+                    creationdate = '         '
+                    creationtime = '         '
+                if f.is_directory:
+                    attrib = 'D...'
+                else:
+                    attrib = '....'
+                if f.archivable:
+                    attrib += 'A'
+                else:
+                    attrib += '.'
+                if f.is_directory:
+                    extra = '           0 '
+                elif f.compressed is None:
+                    extra = '             '
+                else:
+                    extra = '%12d ' % (f.compressed)
+                file.write('%s %s %s %12d %s %s\n' % (creationdate, creationtime, attrib,
+                                                      f.uncompressed, extra, f.filename))
+            file.write('------------------- ----- ------------ ------------  ------------------------\n')
+
         return(0)
+
+    @staticmethod
+    def print_archiveinfo(archive, file):
+        file.write("--\n")
+        file.write("Path = {}\n".format(archive.filename))
+        file.write("Type = 7z\n")
+        fstat = os.stat(archive.filename)
+        file.write("Phisical Size = {}\n".format(fstat.st_size))
+        file.write("Headers Size = {}\n".format(archive.header.size))  # fixme.
+        file.write("Method = {}\n".format(archive._get_method_names()))
+        if archive.solid:
+            file.write("Solid = {}\n".format('+'))
+        else:
+            file.write("Solid = {}\n".format('-'))
+        file.write("Blocks = {}\n".format(len(archive.header.main_streams.unpackinfo.folders)))
 
     def run_test(self, args):
         target = args.arcfile
@@ -104,11 +175,16 @@ class Cli():
             return(1)
         with open(target, 'rb') as f:
             a = py7zr.SevenZipFile(f)
-            res = a.test()
-        if res:
-            return(0)
-        else:
-            return(1)
+            file = sys.stdout
+            file.write("Testing archive: {}\n".format(a.filename))
+            self.print_archiveinfo(archive=a, file=file)
+            file.write('\n')
+            if a.test():
+                file.write('Everything is Ok\n')
+                return(0)
+            else:
+                file.write('Bad 7zip file\n')
+                return(1)
 
     def run_extract(self, args: argparse.Namespace) -> int:
         target = args.arcfile

--- a/py7zr/cli.py
+++ b/py7zr/cli.py
@@ -22,18 +22,18 @@ import os
 import sys
 from lzma import CHECK_CRC64, CHECK_SHA256, is_check_supported
 from typing import Any, Optional
+
 import py7zr
 import texttable  # type: ignore
-
 from py7zr.helpers import Local
 from py7zr.properties import SupportedMethods
 
-class Cli():
 
-    parser: argparse.ArgumentParser = None
+class Cli():
+    def __init__(self):
+        self.parser = self._create_parser()
 
     def run(self, arg: Optional[Any] = None) -> int:
-        self.parser = self._create_parser()
         args = self.parser.parse_args(arg)
         return args.func(args)
 

--- a/py7zr/compression.py
+++ b/py7zr/compression.py
@@ -354,7 +354,7 @@ def get_methods_names(coders: List[dict]) -> List[str]:
         CompressionMethod.LZMA: "LZMA",
         CompressionMethod.DELTA: "delta",
     }
-    methods_names = []
+    methods_names = []  # type: List[str]
     for coder in coders:
         methods_names.append(methods_name_map[coder['method']])
     return methods_names

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -29,9 +29,13 @@ def test_basic_initinfo():
 @pytest.mark.basic
 def test_basic_list_1():
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, 'test_1.7z'), 'rb'))
-    output = io.StringIO()
-    archive.list(file=output)
-    contents = output.getvalue()
+    archive_list = archive.list()
+    # TODO
+
+
+@pytest.mark.cli
+def test_cli_list_1(capsys):
+    arc = os.path.join(testdata_path, 'test_1.7z')
     expected = """total 4 files and directories in solid archive
    Date      Time    Attr         Size   Compressed  Name
 ------------------- ----- ------------ ------------  ------------------------
@@ -41,15 +45,15 @@ def test_basic_list_1():
 2019-03-14 00:09:01 ....A          559               setup.py
 ------------------- ----- ------------ ------------  ------------------------
 """
-    assert expected == contents
+    cli = py7zr.cli.Cli()
+    cli.run(["l", arc])
+    out, err = capsys.readouterr()
+    assert expected == out
 
 
 @pytest.mark.basic
-def test_basic_list_2():
-    archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, 'test_3.7z'), 'rb'))
-    output = io.StringIO()
-    archive.list(file=output)
-    contents = output.getvalue()
+def test_cli_list_2(capsys):
+    arc = os.path.join(testdata_path, 'test_3.7z')
     expected = """total 28 files and directories in solid archive
    Date      Time    Attr         Size   Compressed  Name
 ------------------- ----- ------------ ------------  ------------------------
@@ -83,7 +87,10 @@ def test_basic_list_2():
 2018-10-18 10:28:16 ....A         1064               5.9.7/gcc_64/lib/libQt5X11Extras.prl
 ------------------- ----- ------------ ------------  ------------------------
 """
-    assert expected == contents
+    cli = py7zr.cli.Cli()
+    cli.run(["l", arc])
+    out, err = capsys.readouterr()
+    assert expected == out
 
 
 @pytest.mark.api
@@ -204,10 +211,9 @@ def test_cli_list(capsys):
     assert out == expected
 
 
-@pytest.mark.api
-def test_api_list_verbose(capsys):
+@pytest.mark.cli
+def test_cli_list_verbose(capsys):
     arcfile = os.path.join(testdata_path, "test_1.7z")
-    archive = py7zr.SevenZipFile(open(arcfile, 'rb'))
     expected = """Listing archive: {}
 --
 Path = {}
@@ -227,9 +233,9 @@ total 4 files and directories in solid archive
 2019-03-14 00:09:01 ....A          559               setup.py
 ------------------- ----- ------------ ------------  ------------------------
 """.format(arcfile, arcfile)
-    output = io.StringIO()
-    archive.list(file=output, verbose=True)
-    out = output.getvalue()
+    cli = py7zr.cli.Cli()
+    cli.run(["l", "--verbose", arcfile])
+    out, err = capsys.readouterr()
     assert out == expected
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,3 @@
-import io
 import lzma
 import os
 import shutil

--- a/tests/test_basic_unit.py
+++ b/tests/test_basic_unit.py
@@ -351,9 +351,8 @@ def test_read_crcs():
 @pytest.mark.unit
 def test_file_list_length():
     file_list = py7zr.py7zr.ArchiveFileList()
-    file = py7zr.py7zr.ArchiveFile(0, None)
-    file_list.append(file)
-    assert file_list.len == 1
+    file_list.append(py7zr.py7zr.ArchiveFile(0, None))
+    assert file_list.len() == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Current API includes console interaction. It is not good habits. All of console interaction should be in CLI class and main class should only have a silent API.

Now there are TWO bad APIs and proposals to change

method       |  issue                                                           |  proposal for change
--------------  | --------------------------------------------------------- | --------------------------------------------------
 list             |  list shows archive contents with pretty printing.. It accept file descriptor to output. | return list of contents as a FileInfo object. |
archiveinfo |  pretty printing archive information  | return archive information as ArchiveInfo object. |
 
And then moves pretty printing part into Cli class.