### PR TITLE
Fix logics for retrieving coders

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -322,28 +322,24 @@ class Folder:
 
     def _read(self, file: BinaryIO) -> None:
         num_coders = read_uint64(file)
-        for i in range(num_coders):
-            while True:
-                b = read_byte(file)
-                methodsize = b & 0xf
-                iscomplex = b & 0x10 == 0x10
-                hasattributes = b & 0x20 == 0x20
-                last_alternative = b & 0x80 == 0
-                c = {'method': file.read(methodsize)}  # type: Dict[str, Any]
-                if iscomplex:
-                    c['numinstreams'] = read_uint64(file)
-                    c['numoutstreams'] = read_uint64(file)
-                else:
-                    c['numinstreams'] = 1
-                    c['numoutstreams'] = 1
-                self.totalin += c['numinstreams']
-                self.totalout += c['numoutstreams']
-                if hasattributes:
-                    proplen = read_uint64(file)
-                    c['properties'] = file.read(proplen)
-                self.coders.append(c)
-                if last_alternative:
-                    break
+        for _ in range(num_coders):
+            b = read_byte(file)
+            methodsize = b & 0xf
+            iscomplex = b & 0x10 == 0x10
+            hasattributes = b & 0x20 == 0x20
+            c = {'method': file.read(methodsize)}  # type: Dict[str, Any]
+            if iscomplex:
+                c['numinstreams'] = read_uint64(file)
+                c['numoutstreams'] = read_uint64(file)
+            else:
+                c['numinstreams'] = 1
+                c['numoutstreams'] = 1
+            self.totalin += c['numinstreams']
+            self.totalout += c['numoutstreams']
+            if hasattributes:
+                proplen = read_uint64(file)
+                c['properties'] = file.read(proplen)
+            self.coders.append(c)
         num_bindpairs = self.totalout - 1
         for i in range(num_bindpairs):
             self.bindpairs.append((read_uint64(file), read_uint64(file),))
@@ -361,18 +357,17 @@ class Folder:
         assert num_coders > 0
         write_uint64(file, num_coders)
         for i, c in enumerate(self.coders):
-            method = c['method']  # type: bytes
-            method_size = len(method)
-            numinstreams = c['numinstreams']
-            numoutstreams = c['numoutstreams']
-            iscomplex = 0x00 if numinstreams == 1 and numoutstreams == 1 else 0x10
-            last_alternative = 0x80 if i < num_coders - 1 else 0x00
+            id = c['method']  # type: bytes
+            id_size = len(id) & 0x0f
+            iscomplex = 0x10 if not self.is_simple(c) else 0x00
             hasattributes = 0x20 if c['properties'] is not None else 0x00
-            write_byte(file, struct.pack('B', method_size & 0xf | iscomplex | hasattributes | last_alternative))
-            write_bytes(file, method)
-            if iscomplex == 0x10:
-                write_uint64(file, numinstreams)
-                write_uint64(file, numoutstreams)
+            flag = struct.pack('B', id_size | iscomplex | hasattributes)
+            write_byte(file, flag)
+            write_bytes(file, id[:id_size])
+            if not self.is_simple(c):
+                write_uint64(file, c['numinstreams'])
+                assert c['numoutstreams'] == 1
+                write_uint64(file, c['numoutstreams'])
             if c['properties'] is not None:
                 write_uint64(file, len(c['properties']))
                 write_bytes(file, c['properties'])
@@ -385,6 +380,9 @@ class Folder:
         if num_packedstreams > 1:
             for pi in self.packed_indices:
                 write_uint64(file, pi)
+
+    def is_simple(self, coder):
+        return coder['numinstreams'] == 1 and coder['numoutstreams'] == 1
 
     def get_decompressor(self, size: int) -> SevenZipDecompressor:
         if self.decompressor is not None:


### PR DESCRIPTION
- Drop last_alternative and loop depends on it.
- Current Folder class assume last_alternative flag,
  which does not exist in LZMA SDK 16.00 in p7zip.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>