### PR TITLE
Fix AESDecompressor error when encrypted data is not a size with a multiple of 16byte

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -265,7 +265,7 @@ class PackInfo:
                 pid = file.read(1)
         if pid != Property.END:
             raise Bad7zFile('end id expected but %s found' % repr(pid))
-        self.packpositions = [sum(self.packsizes[:i]) for i in range(self.numstreams)]  # type: List[int]
+        self.packpositions = [sum(self.packsizes[:i]) for i in range(self.numstreams + 1)]  # type: List[int]
         return self
 
     def write(self, file: BinaryIO):

--- a/py7zr/compression.py
+++ b/py7zr/compression.py
@@ -231,7 +231,7 @@ class AESDecompressor:
             temp = self.cipher.decrypt(inp)
             return self.lzma_decompressor.decompress(temp, max_length)
         else:
-            compdata = self.buf  + data
+            compdata = self.buf + data
             currentlen = len(compdata)
             a = currentlen // 16
             nextpos = a * 16

--- a/py7zr/helpers.py
+++ b/py7zr/helpers.py
@@ -21,6 +21,7 @@
 #
 #
 
+import hashlib
 import time as _time
 from datetime import datetime, timedelta, timezone, tzinfo
 from typing import Optional
@@ -40,6 +41,26 @@ def calculate_crc32(data: bytes, value: Optional[int] = None, blocksize: int = 1
         pos += blocksize
 
     return value & 0xffffffff
+
+
+def calculate_key(password: bytes, cycles: int, salt: bytes, digest: str) -> bytes:
+    assert digest == 'sha256'
+    if cycles == 0x3f:
+        ba = bytearray()
+        ba.extend(salt)
+        ba.extend(password)
+        for i in range(32):
+            ba.append(0)
+        key = ba[:32]  # type: bytes
+    else:
+        rounds = 1 << cycles
+        m = hashlib.sha256()
+        for round in range(rounds):
+            m.update(salt)
+            m.update(password)
+            m.update(round.to_bytes(8, byteorder='little', signed=False))
+        key = m.digest()[:32]
+    return key
 
 
 EPOCH_AS_FILETIME = 116444736000000000

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -725,12 +725,18 @@ class SevenZipFile:
             # Currently always overwrite by latter archives.
             # TODO: provide option to select overwrite or skip.
             if f.filename in fnames:
-                multi_thread = False
+                i = 0
+                while True:
+                    outname = f.filename + '_%d' % i
+                    if not outname in fnames:
+                        break
+            else:
+                outname = f.filename
             fnames.append(f.filename)
             if path is not None:
-                outfilename = path.joinpath(f.filename)
+                outfilename = path.joinpath(outname)
             else:
-                outfilename = pathlib.Path(f.filename)
+                outfilename = pathlib.Path(outname)
             if f.is_directory:
                 if not outfilename.exists():
                     target_dirs.append(outfilename)

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -728,7 +728,7 @@ class SevenZipFile:
                 i = 0
                 while True:
                     outname = f.filename + '_%d' % i
-                    if not outname in fnames:
+                    if outname not in fnames:
                         break
             else:
                 outname = f.filename

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,4 +1,5 @@
 import binascii
+import filecmp
 import hashlib
 import lzma
 import os
@@ -150,6 +151,8 @@ def test_compress_files_encoded_header(tmp_path):
     m = hashlib.sha256()
     m.update((tmp_path / 'tgt' / 'scripts' / 'py7zr').open('rb').read())
     assert m.digest() == binascii.unhexlify('b0385e71d6a07eb692f5fb9798e9d33aaf87be7dfff936fd2473eab2a593d4fd')
+    dc = filecmp.dircmp(tmp_path.joinpath('src'), tmp_path.joinpath('tgt'))
+    assert dc.diff_files == []
 
 
 @pytest.mark.basic
@@ -259,6 +262,8 @@ def test_compress_files_1(tmp_path):
     m = hashlib.sha256()
     m.update((tmp_path / 'tgt' / 'scripts' / 'py7zr').open('rb').read())
     assert m.digest() == binascii.unhexlify('b0385e71d6a07eb692f5fb9798e9d33aaf87be7dfff936fd2473eab2a593d4fd')
+    dc = filecmp.dircmp(tmp_path.joinpath('src'), tmp_path.joinpath('tgt'))
+    assert dc.diff_files == []
 
 
 @pytest.mark.api
@@ -320,6 +325,8 @@ def test_compress_files_2(tmp_path):
     reader = py7zr.SevenZipFile(target, 'r')
     reader.extractall(path=tmp_path.joinpath('tgt'))
     reader.close()
+    dc = filecmp.dircmp(tmp_path.joinpath('src'), tmp_path.joinpath('tgt'))
+    assert dc.diff_files == []
 
 
 @pytest.mark.files
@@ -338,6 +345,8 @@ def test_compress_files_3(tmp_path):
     reader = py7zr.SevenZipFile(target, 'r')
     reader.extractall(path=tmp_path.joinpath('tgt'))
     reader.close()
+    dc = filecmp.dircmp(tmp_path.joinpath('src'), tmp_path.joinpath('tgt'))
+    assert dc.diff_files == []
 
 
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -349,7 +349,6 @@ def test_compress_files_3(tmp_path):
     assert dc.diff_files == []
 
 
-
 @pytest.mark.files
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Administrator rights is required to make symlink on windows")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -340,6 +340,7 @@ def test_compress_files_3(tmp_path):
     reader.close()
 
 
+
 @pytest.mark.files
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Administrator rights is required to make symlink on windows")

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -177,6 +177,8 @@ def test_github_14_multi(tmp_path):
     assert archive.getnames() == ['github_14_multi', 'github_14_multi']
     archive.extractall(path=tmp_path)
     with tmp_path.joinpath('github_14_multi').open('rb') as f:
+        assert f.read() == bytes('Hello GitHub issue #14 1/2.\n', 'ascii')
+    with tmp_path.joinpath('github_14_multi_0').open('rb') as f:
         assert f.read() == bytes('Hello GitHub issue #14 2/2.\n', 'ascii')
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -537,7 +537,7 @@ def test_simple_compress_and_decompress():
                            b'e\x11\xf1Pz<*\x98*\xe6\xde\xf4\xf6X\x18\xedl\xf2Be\x1a\xca\x19\xd1\\\xeb\xc6\xa6z\xe2\x89\x1d')
                           ])
 def test_calculate_key(password: str, cycle: int, salt: bytes, expected: bytes):
-    key = py7zr.compression._calculate_key(password.encode('utf-16LE'), cycle, salt, 'sha256')
+    key = py7zr.helpers.calculate_key(password.encode('utf-16LE'), cycle, salt, 'sha256')
     assert key == expected
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -537,7 +537,7 @@ def test_simple_compress_and_decompress():
                            b'e\x11\xf1Pz<*\x98*\xe6\xde\xf4\xf6X\x18\xedl\xf2Be\x1a\xca\x19\xd1\\\xeb\xc6\xa6z\xe2\x89\x1d')
                           ])
 def test_calculate_key(password: str, cycle: int, salt: bytes, expected: bytes):
-    key = py7zr.compression.AESDecompressor._calculate_key(password.encode('utf-16LE'), cycle, salt, 'sha256')
+    key = py7zr.compression._calculate_key(password.encode('utf-16LE'), cycle, salt, 'sha256')
     assert key == expected
 
 


### PR DESCRIPTION
- use data block sized multiple of 16 bytes for AES decyrption.
  thansk for reporting by @andormarkus 

Signed-off-by: Hiroshi Miura <miurahr@linux.com>