### PR TITLE
Use threading for extraction

### DIFF
--- a/py7zr/compression.py
+++ b/py7zr/compression.py
@@ -24,8 +24,8 @@
 import bz2
 import io
 import lzma
-import threading
 import sys
+import threading
 from typing import IO, Any, BinaryIO, Dict, List, Optional, Union
 
 from Crypto.Cipher import AES


### PR DESCRIPTION
As #91 comment https://github.com/miurahr/py7zr/pull/91#issuecomment-592874379
multiprocessing is 5 times behind than threading in performance.

This PR change core extraction strategy to Threading.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>