### PR TITLE
Introduce context manager for SevenZipFile

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -23,7 +23,6 @@
 #
 #
 """Read 7zip format archives."""
-import contextlib
 import datetime
 import errno
 import functools
@@ -43,8 +42,10 @@ from py7zr.helpers import (ArchiveTimestamp, calculate_crc32, filetime_to_dt,
 from py7zr.properties import MAGIC_7Z, READ_BLOCKSIZE, ArchivePassword
 
 if sys.version_info < (3, 6):
+    import contextlib2 as contextlib
     import pathlib2 as pathlib
 else:
+    import contextlib
     import pathlib
 
 if sys.platform.startswith('win'):

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -23,6 +23,7 @@
 #
 #
 """Read 7zip format archives."""
+import contextlib
 import datetime
 import errno
 import functools
@@ -248,7 +249,7 @@ class FileInfo:
         self.creationtime = creationtime
 
 
-class SevenZipFile:
+class SevenZipFile(contextlib.AbstractContextManager):
     """The SevenZipFile Class provides an interface to 7z archives."""
 
     def __init__(self, file: Union[BinaryIO, str, pathlib.Path], mode: str = 'r',
@@ -316,6 +317,12 @@ class SevenZipFile:
             self._fpclose()
             raise e
         self.encoded_header_mode = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
     def _create_folder(self, filters):
         folder = Folder()

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ classifiers =
 install_requires =
       texttable
       pycryptodome
-      contextlib2>0.6.0;python_version<"3.6"
+      contextlib2>=0.6.0;python_version<"3.6"
       pathlib2>=2.2.0;python_version<"3.6"
       pywin32;sys_platform=="win32"
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,9 @@ classifiers =
 [options]
 install_requires =
       texttable
-      pathlib2>=2.2.0;python_version<"3.6"
       pycryptodome
+      contextlib2>0.6.0;python_version<"3.6"
+      pathlib2>=2.2.0;python_version<"3.6"
       pywin32;sys_platform=="win32"
 setup_requires =
       setuptools-scm>=3.5.0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -425,7 +425,7 @@ def test_py7zr_extract_and_reset_iteration(tmp_path):
 
 
 @pytest.mark.api
-def test_context_manager(tmp_path):
+def test_context_manager_1(tmp_path):
     with py7zr.SevenZipFile(os.path.join(testdata_path, 'test_1.7z'), 'r') as z:
         z.extractall(path=tmp_path)
     assert tmp_path.joinpath('scripts').is_dir()
@@ -433,3 +433,9 @@ def test_context_manager(tmp_path):
     assert tmp_path.joinpath('setup.cfg').exists()
     assert tmp_path.joinpath('setup.py').exists()
 
+
+@pytest.mark.api
+def test_context_manager_2(tmp_path):
+    target = tmp_path.joinpath('target.7z')
+    with py7zr.SevenZipFile(target, 'w') as z:
+        z.writeall(os.path.join(testdata_path, "src"), "src")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -422,3 +422,14 @@ def test_py7zr_extract_and_reset_iteration(tmp_path):
     assert tmp_path.joinpath('scripts/py7zr').exists()
     assert tmp_path.joinpath('setup.cfg').exists()
     assert tmp_path.joinpath('setup.py').exists()
+
+
+@pytest.mark.api
+def test_context_manager(tmp_path):
+    with py7zr.SevenZipFile(os.path.join(testdata_path, 'test_1.7z'), 'r') as z:
+        z.extractall(path=tmp_path)
+    assert tmp_path.joinpath('scripts').is_dir()
+    assert tmp_path.joinpath('scripts/py7zr').exists()
+    assert tmp_path.joinpath('setup.cfg').exists()
+    assert tmp_path.joinpath('setup.py').exists()
+


### PR DESCRIPTION
User can instantiate SevenZipFile class like as follows:
```
  with SevenZipFile('archvie.7z', 'r') as z:
      z.extractall(path=target)
```
- Close #77

Signed-off-by: Hiroshi Miura <miurahr@linux.com>