### PR TITLE
Detect empty decompression from decompressor()

### DIFF
--- a/py7zr/compression.py
+++ b/py7zr/compression.py
@@ -245,15 +245,16 @@ class Worker:
             read_size = min(READ_BLOCKSIZE, rest_size)
             if read_size == 0:
                 tmp = decompressor.decompress(b'', max_length)
+                if len(tmp) == 0:
+                    raise Exception("decompression get wrong: no output data.")
             else:
                 inp = fp.read(read_size)
                 tmp = decompressor.decompress(inp, max_length)
             if len(tmp) > 0 and out_remaining >= len(tmp):
                 out_remaining -= len(tmp)
                 fq.write(tmp)
-                if out_remaining <= 0:
-                    break
-        assert out_remaining == 0
+            if out_remaining <= 0:
+                break
         if fp.tell() >= src_end:
             if decompressor.crc is not None and not decompressor.check_crc():
                 print('\nCRC error! expected: {}, real: {}'.format(decompressor.crc, decompressor.digest))

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -138,6 +138,13 @@ def test_extract_lzmabcj_archiveinfo():
 
 
 @pytest.mark.files
+@pytest.mark.xfail(reason="Uknown problem that it become no data exception.")
+def test_extract_lzmabcj(tmp_path):
+    with py7zr.SevenZipFile(os.path.join(testdata_path, 'lzmabcj.7z'), 'r') as ar:
+        ar.extractall(path=tmp_path)
+
+
+@pytest.mark.files
 def test_zerosize(tmp_path):
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, 'zerosize.7z'), 'rb'))
     archive.extractall(path=tmp_path)
@@ -271,7 +278,7 @@ def test_extract_encrypted_1(tmp_path):
 
 
 @pytest.mark.files
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(30)
 def test_extract_encrypted_2(tmp_path):
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, 'encrypted_2.7z'), 'rb'), password='secret')
     archive.extractall(path=tmp_path)


### PR DESCRIPTION
test case lzmabcj.7z become a status decompressor returns no data.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>