### PR TITLE
Add default values for reduce operations

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -173,7 +173,7 @@ def read_boolean(file: BinaryIO, count: int, checkall: bool = False) -> List[boo
 
 
 def write_boolean(file: BinaryIO, booleans: List[bool], all_defined: bool = False):
-    if all_defined and reduce(and_, booleans):
+    if all_defined and reduce(and_, booleans, True):
         file.write(b'\x01')
         return
     elif all_defined:
@@ -768,7 +768,7 @@ class FilesInfo:
                     defined.append(True)
                     num_defined += 1
         size = num_defined * 8 + 2
-        if not reduce(and_, defined):
+        if not reduce(and_, defined, True):
             size += bits_to_bytes(num_defined)
         write_uint64(fp, size)
         write_boolean(fp, defined, all_defined=True)
@@ -786,7 +786,7 @@ class FilesInfo:
     @staticmethod
     def _are_there(vector) -> bool:
         if vector is not None:
-            if functools.reduce(or_, vector):
+            if functools.reduce(or_, vector, False):
                 return True
         return False
 


### PR DESCRIPTION
This fixes exceptions when closing an empty 7z file opened in write mode.

Ex.:

```python
with py7zr.SevenZipFile('/home/andre/test2.7z', 'w') as f:
    print('Will not write anything')
```

results in

```
Traceback (most recent call last):
  File "/home/andre/Development/andrebrait.github.com/1g1r-romset-generator/test.py", line 7, in <module>
    print('Will not write anything')
  File "/home/andre/.local/lib/python3.6/site-packages/py7zr/py7zr.py", line 326, in __exit__
    self.close()
  File "/home/andre/.local/lib/python3.6/site-packages/py7zr/py7zr.py", line 779, in close
    self._write_archive()
  File "/home/andre/.local/lib/python3.6/site-packages/py7zr/py7zr.py", line 562, in _write_archive
    encoded=self.encoded_header_mode)
  File "/home/andre/.local/lib/python3.6/site-packages/py7zr/archiveinfo.py", line 972, in write
    self.files_info.write(file)
  File "/home/andre/.local/lib/python3.6/site-packages/py7zr/archiveinfo.py", line 837, in write
    if self._are_there(emptystreams):
  File "/home/andre/.local/lib/python3.6/site-packages/py7zr/archiveinfo.py", line 789, in _are_there
    if functools.reduce(or_, vector):
TypeError: reduce() of empty sequence with no initial value

Process finished with exit code 1
```