### PR TITLE
Support dereference option

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 Added
 -----
 
+* Support dereference option of SevenZipFile class.
+  If dereference is False, add symbolic and hard links to the archive.
+  If it is True, add the content of the target files to the archive.
+  This has no effect on systems that do not support symbolic links.
+
+
 Changed
 -------
 

--- a/docs/py7zr.rst
+++ b/docs/py7zr.rst
@@ -107,7 +107,7 @@ SevenZipFile Object
 -------------------
 
 
-.. class:: SevenZipFile(file, mode='r', filters=None)
+.. class:: SevenZipFile(file, mode='r', filters=None, dereference=False, password=None)
 
    Open a 7z file, where *file* can be a path to a file (a string), a
    file-like object or a :term:`path-like object`.
@@ -125,10 +125,17 @@ SevenZipFile Object
    SevenZipFile class has a capability as context manager. It can handle
    'with' statement.
 
+   If dereference is False, add symbolic and hard links to the archive.
+   If it is True, add the content of the target files to the archive.
+   This has no effect on systems that do not support symbolic links.
+
+   When password given, py7zr handles an archive as an encrypted one.
+
 .. method:: SevenZipFile.close()
 
-   Close the archive file.  You must call :meth:`close` before exiting your program
-   or most records will not be written.
+   Close the archive file and release internal buffers.  You must
+   call :meth:`close` before exiting your program or most records will
+   not be written.
 
 
 .. method:: SevenZipFile.getnames()
@@ -169,7 +176,7 @@ SevenZipFile Object
 
    with SevenZipFile('archive.7z', 'r') as zip:
         archives = zip.readall()
-        for fname in archives:
+        for fname in zip.readall():
             bio = archives[fname]
             data = bio.read()
 

--- a/py7zr/compression.py
+++ b/py7zr/compression.py
@@ -164,7 +164,7 @@ class Worker:
             member = linkname
         return member
 
-    def archive(self, fp: BinaryIO, folder):
+    def archive(self, fp: BinaryIO, folder, deref=False):
         """Run archive task for specified 7zip folder."""
         compressor = folder.get_compressor()
         outsize = 0
@@ -179,7 +179,7 @@ class Worker:
             self.header.files_info.files.append(file_info)
             self.header.files_info.emptyfiles.append(f.emptystream)
             foutsize = 0
-            if f.is_symlink:
+            if f.is_symlink and not deref:
                 last_file_index = i
                 num_unpack_streams += 1
                 link_target = self._find_link_target(f.origin)  # type: str

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -37,7 +37,7 @@ from typing import IO, Any, BinaryIO, Dict, List, Optional, Tuple, Union
 
 from py7zr.archiveinfo import Folder, Header, SignatureHeader
 from py7zr.compression import SevenZipCompressor, Worker, get_methods_names
-from py7zr.exceptions import Bad7zFile, ArchiveError
+from py7zr.exceptions import ArchiveError, Bad7zFile
 from py7zr.helpers import ArchiveTimestamp, MemIO, calculate_crc32, filetime_to_dt
 from py7zr.properties import MAGIC_7Z, READ_BLOCKSIZE, ArchivePassword
 

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -812,7 +812,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         """Write files in target path into archive."""
         if isinstance(path, str):
             path = pathlib.Path(path)
-        if path.is_symlink():
+        if path.is_symlink() and not self.dereference:
             self.write(path, arcname)
         elif path.is_file():
             self.write(path, arcname)

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -590,7 +590,8 @@ class SevenZipFile(contextlib.AbstractContextManager):
                 return True
         return False
 
-    def _make_file_info(self, target: pathlib.Path, arcname: Optional[str] = None) -> Dict[str, Any]:
+    @staticmethod
+    def _make_file_info(target: pathlib.Path, arcname: Optional[str] = None, dereference=False) -> Dict[str, Any]:
         f = {}  # type: Dict[str, Any]
         f['origin'] = target
         if arcname is not None:
@@ -600,7 +601,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         if os.name == 'nt':
             fstat = target.lstat()
             if target.is_symlink():
-                if self.dereference:
+                if dereference:
                     fstat = target.stat()
                     if stat.S_ISDIR(fstat.st_mode):
                         f['emptystream'] = True
@@ -623,7 +624,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         else:
             fstat = target.lstat()
             if target.is_symlink():
-                if self.dereference:
+                if dereference:
                     fstat = target.stat()
                     if stat.S_ISDIR(fstat.st_mode):
                         f['emptystream'] = True
@@ -831,7 +832,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
             path = file
         else:
             raise ValueError("Unsupported file type.")
-        file_info = self._make_file_info(path, arcname)
+        file_info = self._make_file_info(path, arcname, self.dereference)
         self.files.append(file_info)
 
     def close(self):

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -37,7 +37,7 @@ from typing import IO, Any, BinaryIO, Dict, List, Optional, Tuple, Union
 
 from py7zr.archiveinfo import Folder, Header, SignatureHeader
 from py7zr.compression import SevenZipCompressor, Worker, get_methods_names
-from py7zr.exceptions import ArchiveError, Bad7zFile
+from py7zr.exceptions import Bad7zFile
 from py7zr.helpers import ArchiveTimestamp, MemIO, calculate_crc32, filetime_to_dt
 from py7zr.properties import MAGIC_7Z, READ_BLOCKSIZE, ArchivePassword
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -542,6 +542,5 @@ def test_compress_files_deref_loop(tmp_path):
     os.chdir(tmp_path.joinpath('src'))
     # create symlink loop
     tmp_path.joinpath('src/lib/parent').symlink_to(tmp_path.joinpath('src/lib'), target_is_directory=True)
-    with pytest.raises(ArchiveError):
-        with py7zr.SevenZipFile(target, 'w', dereference=True) as archive:
-            archive.writeall('.')
+    with py7zr.SevenZipFile(target, 'w', dereference=True) as archive:
+        archive.writeall('.')

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -527,3 +527,6 @@ def test_compress_files_deref(tmp_path):
     reader = py7zr.SevenZipFile(target, 'r')
     reader.extractall(path=tmp_path.joinpath('tgt'))
     reader.close()
+    assert tmp_path.joinpath('tgt').joinpath('lib64').is_dir()
+    assert tmp_path.joinpath('tgt').joinpath('lib/libabc.so').is_file()
+    assert tmp_path.joinpath('tgt').joinpath('lib64/libabc.so').is_file()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -17,7 +17,6 @@ import py7zr.compression
 import py7zr.helpers
 import py7zr.properties
 from py7zr import SevenZipFile, pack_7zarchive
-from py7zr.exceptions import ArchiveError
 from py7zr.py7zr import FILE_ATTRIBUTE_UNIX_EXTENSION
 
 from . import ltime


### PR DESCRIPTION
Add support of dereference option(#123)

With dereference= True specified, py7zr will dereference symbolic link to normal files.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>