### PR TITLE
Introduce helpers.calculate_key3()

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,9 +1,11 @@
 import os
+import platform
 import tempfile
 
 import pytest
 
 import py7zr
+import py7zr.helpers
 
 testdata_path = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -21,3 +23,34 @@ def test_extract_benchmark(tmp_path, benchmark, data, password):
         szf.close()
 
     benchmark(extractor, tmp_path, data, password)
+
+
+@pytest.mark.benchmark
+def test_benchmark_calculate_key1(benchmark):
+    password = 'secret'.encode('utf-16LE')
+    cycles = 19
+    salt = b''
+    expected = b'e\x11\xf1Pz<*\x98*\xe6\xde\xf4\xf6X\x18\xedl\xf2Be\x1a\xca\x19\xd1\\\xeb\xc6\xa6z\xe2\x89\x1d'
+    key = benchmark(py7zr.helpers._calculate_key1, password, cycles, salt, 'sha256')
+    assert key == expected
+
+
+@pytest.mark.benchmark
+@pytest.mark.skipif(platform.python_implementation() == "PyPy", reason="Pypy has a bug around ctypes")
+def test_benchmark_calculate_key2(benchmark):
+    password = 'secret'.encode('utf-16LE')
+    cycles = 19
+    salt = b''
+    expected = b'e\x11\xf1Pz<*\x98*\xe6\xde\xf4\xf6X\x18\xedl\xf2Be\x1a\xca\x19\xd1\\\xeb\xc6\xa6z\xe2\x89\x1d'
+    key = benchmark(py7zr.helpers._calculate_key2, password, cycles, salt, 'sha256')
+    assert key == expected
+
+
+@pytest.mark.benchmark
+def test_benchmark_calculate_key3(benchmark):
+    password = 'secret'.encode('utf-16LE')
+    cycles = 19
+    salt = b''
+    expected = b'e\x11\xf1Pz<*\x98*\xe6\xde\xf4\xf6X\x18\xedl\xf2Be\x1a\xca\x19\xd1\\\xeb\xc6\xa6z\xe2\x89\x1d'
+    key = benchmark(py7zr.helpers._calculate_key3, password, cycles, salt, 'sha256')
+    assert key == expected

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -544,7 +544,9 @@ def test_archive_password():
 @pytest.mark.unit
 @pytest.mark.parametrize("password, cycle, salt, expected",
                          [('secret^&', 0x3f, b'i@#ri#Ildajfdk',
-                           b'i@#ri#Ildajfdks\x00e\x00c\x00r\x00e\x00t\x00^\x00&\x00\x00\x00')
+                           b'i@#ri#Ildajfdks\x00e\x00c\x00r\x00e\x00t\x00^\x00&\x00\x00\x00'),
+                          ('secret', 5, b'', b'(6\xa7\xf0\xcc"\t\x9dod\xe2\x8d\xd2\xe9\x08^s\x9c\x99-\xa3N\x08\x10'
+                                             b'\x9e\\~\x89<\x1cR\xc2')
                           ])
 def test_calculate_key1(password: str, cycle: int, salt: bytes, expected: bytes):
     key = py7zr.helpers._calculate_key1(password.encode('utf-16LE'), cycle, salt, 'sha256')
@@ -554,7 +556,9 @@ def test_calculate_key1(password: str, cycle: int, salt: bytes, expected: bytes)
 @pytest.mark.unit
 @pytest.mark.parametrize("password, cycle, salt, expected",
                          [('secret^&', 0x3f, b'i@#ri#Ildajfdk',
-                           b'i@#ri#Ildajfdks\x00e\x00c\x00r\x00e\x00t\x00^\x00&\x00\x00\x00')
+                           b'i@#ri#Ildajfdks\x00e\x00c\x00r\x00e\x00t\x00^\x00&\x00\x00\x00'),
+                          ('secret', 5, b'', b'(6\xa7\xf0\xcc"\t\x9dod\xe2\x8d\xd2\xe9\x08^s\x9c\x99-\xa3N\x08\x10'
+                                             b'\x9e\\~\x89<\x1cR\xc2')
                           ])
 def test_calculate_key2(password: str, cycle: int, salt: bytes, expected: bytes):
     key = py7zr.helpers._calculate_key2(password.encode('utf-16LE'), cycle, salt, 'sha256')
@@ -564,7 +568,9 @@ def test_calculate_key2(password: str, cycle: int, salt: bytes, expected: bytes)
 @pytest.mark.unit
 @pytest.mark.parametrize("password, cycle, salt, expected",
                          [('secret^&', 0x3f, b'i@#ri#Ildajfdk',
-                           b'i@#ri#Ildajfdks\x00e\x00c\x00r\x00e\x00t\x00^\x00&\x00\x00\x00')
+                           b'i@#ri#Ildajfdks\x00e\x00c\x00r\x00e\x00t\x00^\x00&\x00\x00\x00'),
+                          ('secret', 5, b'', b'(6\xa7\xf0\xcc"\t\x9dod\xe2\x8d\xd2\xe9\x08^s\x9c\x99-\xa3N\x08\x10'
+                                             b'\x9e\\~\x89<\x1cR\xc2')
                           ])
 def test_calculate_key3(password: str, cycle: int, salt: bytes, expected: bytes):
     key = py7zr.helpers._calculate_key3(password.encode('utf-16LE'), cycle, salt, 'sha256')

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -561,6 +561,16 @@ def test_calculate_key2(password: str, cycle: int, salt: bytes, expected: bytes)
     assert key == expected
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize("password, cycle, salt, expected",
+                         [('secret^&', 0x3f, b'i@#ri#Ildajfdk',
+                           b'i@#ri#Ildajfdks\x00e\x00c\x00r\x00e\x00t\x00^\x00&\x00\x00\x00')
+                          ])
+def test_calculate_key3(password: str, cycle: int, salt: bytes, expected: bytes):
+    key = py7zr.helpers._calculate_key3(password.encode('utf-16LE'), cycle, salt, 'sha256')
+    assert key == expected
+
+
 def test_calculate_key1_nohash():
     with pytest.raises(ValueError):
         py7zr.helpers._calculate_key1('secret'.encode('utf-16LE'), 16, b'', 'sha123')
@@ -569,6 +579,11 @@ def test_calculate_key1_nohash():
 def test_calculate_key2_nohash():
     with pytest.raises(ValueError):
         py7zr.helpers._calculate_key2('secret'.encode('utf-16LE'), 16, b'', 'sha123')
+
+
+def test_calculate_key3_nohash():
+    with pytest.raises(ValueError):
+        py7zr.helpers._calculate_key3('secret'.encode('utf-16LE'), 16, b'', 'sha123')
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,7 +4,6 @@ import datetime
 import io
 import lzma
 import os
-import platform
 import stat
 import struct
 import sys
@@ -570,27 +569,6 @@ def test_calculate_key1_nohash():
 def test_calculate_key2_nohash():
     with pytest.raises(ValueError):
         py7zr.helpers._calculate_key2('secret'.encode('utf-16LE'), 16, b'', 'sha123')
-
-
-@pytest.mark.benchmark
-def test_benchmark_calculate_key1(benchmark):
-    password = 'secret'.encode('utf-16LE')
-    cycles = 19
-    salt = b''
-    expected = b'e\x11\xf1Pz<*\x98*\xe6\xde\xf4\xf6X\x18\xedl\xf2Be\x1a\xca\x19\xd1\\\xeb\xc6\xa6z\xe2\x89\x1d'
-    key = benchmark(py7zr.helpers._calculate_key1, password, cycles, salt, 'sha256')
-    assert key == expected
-
-
-@pytest.mark.benchmark
-@pytest.mark.skipif(platform.python_implementation() == "PyPy", reason="Pypy has a bug around ctypes")
-def test_benchmark_calculate_key2(benchmark):
-    password = 'secret'.encode('utf-16LE')
-    cycles = 19
-    salt = b''
-    expected = b'e\x11\xf1Pz<*\x98*\xe6\xde\xf4\xf6X\x18\xedl\xf2Be\x1a\xca\x19\xd1\\\xeb\xc6\xa6z\xe2\x89\x1d'
-    key = benchmark(py7zr.helpers._calculate_key2, password, cycles, salt, 'sha256')
-    assert key == expected
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -556,9 +556,7 @@ def test_calculate_key1(password: str, cycle: int, salt: bytes, expected: bytes)
 @pytest.mark.unit
 @pytest.mark.parametrize("password, cycle, salt, expected",
                          [('secret^&', 0x3f, b'i@#ri#Ildajfdk',
-                           b'i@#ri#Ildajfdks\x00e\x00c\x00r\x00e\x00t\x00^\x00&\x00\x00\x00'),
-                          ('secret', 5, b'', b'(6\xa7\xf0\xcc"\t\x9dod\xe2\x8d\xd2\xe9\x08^s\x9c\x99-\xa3N\x08\x10'
-                                             b'\x9e\\~\x89<\x1cR\xc2')
+                           b'i@#ri#Ildajfdks\x00e\x00c\x00r\x00e\x00t\x00^\x00&\x00\x00\x00')
                           ])
 def test_calculate_key2(password: str, cycle: int, salt: bytes, expected: bytes):
     key = py7zr.helpers._calculate_key2(password.encode('utf-16LE'), cycle, salt, 'sha256')


### PR DESCRIPTION
Indroduce helper function calculate_key3() which utilize list comprehension expression, bytes generation with join() and reduce a number of calls of update() by concatination of input values in 2048 bytes.

Hash.update(a + b) is equals to Hash.update(a) and Hash.update(b)

Signed-off-by: Hiroshi Miura <miurahr@linux.com>