### PR TITLE
Does not raise BufferOverflow and extend buffer size when necessary

### DIFF
--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -76,7 +76,7 @@ class AESCompressor(ISevenZipCompressor):
         self.iv += bytes(self.AES_CBC_BLOCKSIZE - len(self.iv))  # zero padding if iv < AES_CBC_BLOCKSIZE
         self.cipher = AES.new(key, AES.MODE_CBC, self.iv)
         self.flushed = False
-        self.buf = Buffer(size=READ_BLOCKSIZE + self.AES_CBC_BLOCKSIZE)
+        self.buf = Buffer(size=READ_BLOCKSIZE + self.AES_CBC_BLOCKSIZE * 2)
 
     def encode_filter_properties(self):
         # cycles = secrets.SystemRandom().randint(1, 23)

--- a/py7zr/helpers.py
+++ b/py7zr/helpers.py
@@ -375,8 +375,11 @@ class Buffer:
     def add(self, data: Union[bytes, bytearray, memoryview]):
         length = len(data)
         if length + self._buflen > self._size:
-            raise BufferOverflow()  # pragma: no-cover
-        self._buf[self._buflen:self._buflen + length] = data
+            # extend buffer
+            self._buf = self._buf[:self._buflen] + data
+            self._size = self._buflen + length
+        else:
+            self._buf[self._buflen:self._buflen + length] = data
         self._buflen += length
         self.view = memoryview(self._buf[0:self._buflen])
 
@@ -387,8 +390,11 @@ class Buffer:
     def set(self, data: Union[bytes, bytearray, memoryview]) -> None:
         length = len(data)
         if length > self._size:
-            raise BufferOverflow()  # pragma: no-cover
-        self._buf[0:length] = data
+            # extend buffer
+            self._buf = bytearray(data)
+            self._size = length
+        else:
+            self._buf[0:length] = data
         self._buflen = length
         self.view = memoryview(self._buf[0:length])
 

--- a/py7zr/helpers.py
+++ b/py7zr/helpers.py
@@ -360,10 +360,6 @@ class NullIO:
         pass
 
 
-class BufferOverflow(Exception):
-    pass
-
-
 class Buffer:
 
     def __init__(self, size: int = 16):

--- a/py7zr/helpers.py
+++ b/py7zr/helpers.py
@@ -367,19 +367,13 @@ class BufferOverflow(Exception):
 class Buffer:
 
     def __init__(self, size: int = 16):
-        self._size = size
         self._buf = bytearray(size)
         self._buflen = 0
         self.view = memoryview(self._buf[0:0])
 
     def add(self, data: Union[bytes, bytearray, memoryview]):
         length = len(data)
-        if length + self._buflen > self._size:
-            # extend buffer
-            self._buf = self._buf[:self._buflen] + data
-            self._size = self._buflen + length
-        else:
-            self._buf[self._buflen:self._buflen + length] = data
+        self._buf[self._buflen:] = data
         self._buflen += length
         self.view = memoryview(self._buf[0:self._buflen])
 
@@ -389,12 +383,7 @@ class Buffer:
 
     def set(self, data: Union[bytes, bytearray, memoryview]) -> None:
         length = len(data)
-        if length > self._size:
-            # extend buffer
-            self._buf = bytearray(data)
-            self._size = length
-        else:
-            self._buf[0:length] = data
+        self._buf[0:] = data
         self._buflen = length
         self.view = memoryview(self._buf[0:length])
 

--- a/py7zr/properties.py
+++ b/py7zr/properties.py
@@ -33,7 +33,7 @@ if platform.python_implementation() == "PyPy" and sys.version_info >= (3, 6, 9):
 elif sys.version_info >= (3, 7, 5):
     READ_BLOCKSIZE = 1048576
 else:
-    READ_BLOCKSIZE = 32248
+    READ_BLOCKSIZE = 32768
 QUEUELEN = READ_BLOCKSIZE * 2
 COMMAND_HELP_STRING = '''<Commands>
   c : Create archive with files


### PR DESCRIPTION
* Set buffer size to READ_BLOCKSIZE + CBC_BLOCKSIZE * 2
* Change default buffer size for python < v3.7.5 to 32768 bytes.
* Try to fix #201

Signed-off-by: Hiroshi Miura <miurahr@linux.com>