### PR TITLE
Raise PasswordRequired exception when no password

### DIFF
--- a/py7zr/__init__.py
+++ b/py7zr/__init__.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     from importlib_metadata import PackageNotFoundError, version  # type: ignore
 
-from py7zr.exceptions import Bad7zFile, DecompressionError, UnsupportedCompressionMethodError
+from py7zr.exceptions import Bad7zFile, DecompressionError, PasswordRequired, UnsupportedCompressionMethodError
 from py7zr.properties import (CHECK_CRC32, CHECK_CRC64, CHECK_NONE, CHECK_SHA256, FILTER_ARM, FILTER_ARMTHUMB, FILTER_BZIP2,
                               FILTER_COPY, FILTER_CRYPTO_AES256_SHA256, FILTER_DEFLATE, FILTER_DELTA, FILTER_IA64,
                               FILTER_LZMA, FILTER_LZMA2, FILTER_POWERPC, FILTER_SPARC, FILTER_X86, FILTER_ZSTD,
@@ -38,7 +38,7 @@ except PackageNotFoundError:  # pragma: no-cover
     __version__ = "unknown"
 
 __all__ = ['__version__', 'ArchiveInfo', 'FileInfo', 'SevenZipFile', 'is_7zfile', 'pack_7zarchive', 'unpack_7zarchive',
-           'UnsupportedCompressionMethodError', 'Bad7zFile', 'DecompressionError',
+           'PasswordRequired', 'UnsupportedCompressionMethodError', 'Bad7zFile', 'DecompressionError',
            'FILTER_LZMA', 'FILTER_LZMA2', 'FILTER_DELTA', 'FILTER_COPY', 'FILTER_CRYPTO_AES256_SHA256',
            'FILTER_X86', 'FILTER_ARM', 'FILTER_SPARC', 'FILTER_POWERPC', 'FILTER_IA64', 'FILTER_ARMTHUMB',
            'FILTER_BZIP2', 'FILTER_DEFLATE', 'FILTER_ZSTD',

--- a/py7zr/cli.py
+++ b/py7zr/cli.py
@@ -282,7 +282,7 @@ class Cli():
             print('Header is corrupted. Cannot read as 7z file.')
             return 1
         except py7zr.exceptions.PasswordRequired:
-            print('The archive seems to be encrypted, and password is required...aborted.')
+            print('The archive is encrypted, but password is not given. ABORT.')
             return 1
 
         cb = None  # Optional[ExtractCallback]
@@ -299,6 +299,9 @@ class Cli():
             return 1
         except py7zr.exceptions.DecompressionError:
             print("Error has been occurred during decompression. ABORT.")
+            return 1
+        except py7zr.exceptions.PasswordRequired:
+            print('The archive is encrypted, but password is not given. ABORT.')
             return 1
         else:
             return 0

--- a/py7zr/exceptions.py
+++ b/py7zr/exceptions.py
@@ -44,3 +44,7 @@ class DecompressionError(ArchiveError):
 
 class InternalError(ArchiveError):
     pass
+
+
+class PasswordRequired(Exception):
+    pass

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -11,6 +11,7 @@ import py7zr.archiveinfo
 import py7zr.compressor
 import py7zr.helpers
 import py7zr.properties
+from py7zr import PasswordRequired
 from py7zr.properties import CompressionMethod
 
 testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath('data')
@@ -29,6 +30,13 @@ def test_extract_encrypted_1_mem():
     archive = py7zr.SevenZipFile(testdata_path.joinpath('encrypted_1.7z').open(mode='rb'), password='secret')
     _dict = archive.readall()
     archive.close()
+
+
+@pytest.mark.files
+def test_extract_encrypted_no_password(tmp_path):
+    with pytest.raises(PasswordRequired):
+        with py7zr.SevenZipFile(testdata_path.joinpath('encrypted_1.7z').open(mode='rb'), password=None) as archive:
+            archive.extractall(path=tmp_path)
 
 
 @pytest.mark.files

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -39,6 +39,27 @@ def test_extract_encrypted_no_password(tmp_path):
             archive.extractall(path=tmp_path)
 
 
+@pytest.mark.cli
+def test_cli_encrypted_no_password(capsys):
+    arcfile = os.path.join(testdata_path, 'encrypted_1.7z')
+    expected = """Testing archive: {}
+--
+Path = {}
+Type = 7z
+Phisical Size = 251
+Headers Size = 203
+Method = LZMA, 7zAES
+Solid = +
+Blocks = 1
+
+The archive is encrypted but password is not given. FAILED.
+""".format(arcfile, arcfile)
+    cli = py7zr.cli.Cli()
+    cli.run(["t", arcfile])
+    out, err = capsys.readouterr()
+    assert out == expected
+
+
 @pytest.mark.files
 @pytest.mark.timeout(30)
 @pytest.mark.skipif(sys.platform.startswith("win") and (ctypes.windll.shell32.IsUserAnAdmin() == 0),


### PR DESCRIPTION
When extracting encrypted archive without specified
password, it should raise proper exception.

Fixed #215

Signed-off-by: Hiroshi Miura <miurahr@linux.com>