### PR TITLE
Support needs_password method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -122,6 +122,12 @@ SevenZipFile Object
    Return a list of archive files by name.
 
 
+.. method:: SevenZipFile.needs_password()
+
+   Return `True` if the archive is encrypted, or is going to create
+   encrypted archive. Otherwise return `False`
+
+
 .. method:: SevenZipFile.extractall(path=None)
 
    Extract all members from the archive to current working directory.  *path*

--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -897,7 +897,10 @@ class SupportedMethods:
 
     @classmethod
     def get_filter_id(cls, coder):
-        return cls._find_method('id', coder['method'])['filter_id']
+        method = cls._find_method('id', coder['method'])
+        if method is None:
+            return None
+        return method['filter_id']
 
     @classmethod
     def is_native_filter(cls, filter) -> bool:
@@ -952,6 +955,16 @@ class SupportedMethods:
         else:
             properties = None
         return {'method': method, 'properties': properties, 'numinstreams': 1, 'numoutstreams': 1}
+
+    @classmethod
+    def needs_password(cls, coders) -> bool:
+        for coder in coders:
+            filter_id = SupportedMethods.get_filter_id(coder)
+            if filter_id is None:
+                continue
+            if SupportedMethods.is_crypto_id(filter_id):
+                return True
+        return False
 
 
 def get_methods_names_string(coders_lists: List[List[dict]]) -> str:

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -34,9 +34,15 @@ def test_extract_encrypted_1_mem():
 
 @pytest.mark.files
 def test_extract_encrypted_no_password(tmp_path):
-    with pytest.raises(PasswordRequired):
-        with py7zr.SevenZipFile(testdata_path.joinpath('encrypted_1.7z').open(mode='rb'), password=None) as archive:
+    with py7zr.SevenZipFile(testdata_path.joinpath('encrypted_1.7z').open(mode='rb'), password=None) as archive:
+        with pytest.raises(PasswordRequired):
             archive.extractall(path=tmp_path)
+
+
+@pytest.mark.files
+def test_extract_encrypted_needs_password(tmp_path):
+    with py7zr.SevenZipFile(testdata_path.joinpath('encrypted_1.7z').open(mode='rb'), password=None) as archive:
+        assert archive.needs_password()
 
 
 @pytest.mark.files


### PR DESCRIPTION
Trial to implement needs_password() method.
When header is encrypted, SevenZipFile object constructor simply raise PasswordRequired exception as same as before.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>