### PR TITLE
No longer check compression level for ZstdDecompressor 

### DIFF
--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -254,16 +254,13 @@ class ZstdDecompressor(ISevenZipDecompressor):
         if len(properties) == 3 or len(properties) == 5:
             _major = properties[0]
             _minor = properties[1]
-            _level = properties[2]
             required_version = (_major, _minor, 0)
         else:
             raise UnsupportedCompressionMethodError
         if Zstd.ZSTD_VERSION < required_version:
             raise UnsupportedCompressionMethodError
-        if 0 < _level <= 22:
-            ctc = Zstd.ZstdDecompressor()  # type: ignore
-        else:
-            raise UnsupportedCompressionMethodError
+
+        ctc = Zstd.ZstdDecompressor()  # type: ignore
         self.dobj = ctc.decompressobj()  # type: ignore
 
     def decompress(self, data: Union[bytes, bytearray, memoryview], max_length: int = -1) -> bytes:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -22,7 +22,7 @@ from py7zr.py7zr import FILE_ATTRIBUTE_UNIX_EXTENSION
 from . import libarchive_extract, ltime, p7zip_test
 
 try:
-    import zstd as Zstd
+    import zstandard as Zstd  # type: ignore
 except ImportError:
     Zstd = None
 


### PR DESCRIPTION
Fix wrong zstandard module name in test_archive.py

Issue https://github.com/miurahr/py7zr/issues/256