### PR TITLE
methods to set header encode mode

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -244,6 +244,17 @@ SevenZipFile Object
    then archive listed as ['c', 'c/d.txt'], the former as directory.
 
 
+.. method:: SevenZipFile.set_encrypted_header(mode)
+
+   Set header encryption mode. When encrypt header, set mode to `True`, otherwise `False`.
+   Default is `False`.
+
+
+.. method:: SevenZipFile.set_encoded_header_mode(mode)
+
+   Set header encode mode. When encode header data, set mode to `True`, otherwise `False`.
+   Default is `True`.
+
 
 Compression Methods
 ===================


### PR DESCRIPTION
Introduce methods to set header encoding mode.
 
Signed-off-by: Hiroshi Miura <miurahr@linux.com>