### PR TITLE
Fix  KeyError: 'properties' when appending to LZMA2+BCJ archive.

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -328,6 +328,8 @@ class Folder:
             if hasattributes:
                 proplen = read_uint64(file)
                 c['properties'] = file.read(proplen)
+            else:
+                c['properties'] = None
             self.coders.append(c)
         num_bindpairs = totalout - 1
         for i in range(num_bindpairs):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -847,6 +847,20 @@ def test_compress_append(tmp_path):
 
 
 @pytest.mark.files
+def test_compress_append_2(tmp_path):
+    target = tmp_path.joinpath('target.7z')
+    shutil.copy(os.path.join(testdata_path, "lzma2bcj.7z"), target)
+    with py7zr.SevenZipFile(target, mode='a') as archive:
+        archive.write(os.path.join(testdata_path, "test1.txt"), "test1.txt")
+    #
+    with py7zr.SevenZipFile(target, 'r') as archive:
+        archive.extractall(path=tmp_path / 'tgt')
+    #
+    p7zip_test(tmp_path / 'target.7z')
+    libarchive_extract(tmp_path / 'target.7z', tmp_path.joinpath('tgt2'))
+
+
+@pytest.mark.files
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_append_files_2(tmp_path):
     tmp_path.joinpath('src').mkdir()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -74,11 +74,3 @@ def test_bcj_file(tmp_path):
             ar.extractall(tmp_path.joinpath('tgt'))
         p7zip_test(target)
         libarchive_extract(target, tmp_path / 'tgt2')
-
-
-def test_issue266(tmp_path):
-    file_path = testdata_path.joinpath("src/bra.txt")
-    z_path = tmp_path.joinpath("Logs.7z")
-    shutil.copy(testdata_path.joinpath("lzma2bcj.7z"), z_path)
-    with py7zr.SevenZipFile(z_path, 'a') as archive:
-        archive.write(file=file_path)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -74,3 +74,11 @@ def test_bcj_file(tmp_path):
             ar.extractall(tmp_path.joinpath('tgt'))
         p7zip_test(target)
         libarchive_extract(target, tmp_path / 'tgt2')
+
+
+def test_issue266(tmp_path):
+    file_path = testdata_path.joinpath("src/bra.txt")
+    z_path = tmp_path.joinpath("Logs.7z")
+    shutil.copy(testdata_path.joinpath("lzma2bcj.7z"), z_path)
+    with py7zr.SevenZipFile(z_path, 'a') as archive:
+        archive.write(file=file_path)


### PR DESCRIPTION
Reproduce the case #266 and fix

Signed-off-by: Hiroshi Miura <miurahr@linux.com>