### PR TITLE
Fixed bug processing large compressed headers

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -897,7 +897,7 @@ class Header:
             folder_data = bytearray()
             while remaining > 0:
                 folder_data += decompressor.decompress(fp, max_length=remaining)
-                remaining -= len(folder_data)
+                remaining = uncompressed_size - len(folder_data)
             self.size += compressed_size
             src_start += compressed_size
             if folder.digestdefined:


### PR DESCRIPTION
Encountered an "Bad7zFile: invalid block data" error when decompressing a valid multi-gigabyte file. Eventually after spending far too much time I traced it down to this line of code!

Theres also a small possibility this might fix #272