### PR TITLE
setup.cfg: remove build-time dependency on things unrelated to building

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,6 @@ install_requires =
 setup_requires =
       setuptools-scm>=3.5.0
       setuptools>=42.0
-      wheel
-      pep517
 packages = py7zr
 
 [options.entry_points]


### PR DESCRIPTION
pep517 is a command-line tool used by developers interested in building any package, it does not need to be listed as a requirement which `python -m pep517.build` installs into the isolated build environment.

wheel is used optionally by setuptools to run bdist_wheel and is required by the pep517 build backend... but this is only needed if
you're using pyproject.toml's build-system.requires, so this is a duplicate line.