### PR TITLE
Introduce writef() and writestr() method

### DIFF
--- a/py7zr/helpers.py
+++ b/py7zr/helpers.py
@@ -245,6 +245,10 @@ class ArchiveTimestamp(int):
     def from_datetime(val):
         return ArchiveTimestamp((val - TIMESTAMP_ADJUST) * 10000000.0)
 
+    @staticmethod
+    def from_now():
+        return ArchiveTimestamp((_time.time() - TIMESTAMP_ADJUST) * 10000000.0)
+
 
 def islink(path):
     """

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -914,15 +914,13 @@ class SevenZipFile(contextlib.AbstractContextManager):
     def writef(self, bio: BinaryIO, arcname: str):
         if isinstance(bio, io.BytesIO):
             size = bio.getbuffer().nbytes
-        elif isinstance(bio, io.BufferedIOBase):
-            size = bio.__sizeof__()
         elif isinstance(bio, io.TextIOBase):
             # First check whether is it Text?
             raise ValueError("Unsupported file object type: please open file with Binary mode.")
-        elif hasattr(bio, "read") and hasattr(bio, "__len__"):
-            # Allow objet type which has read() and length methods for duck typing
-            size = len(bio)
+        elif isinstance(bio, io.BufferedIOBase):
+            size = bio.__sizeof__()
         elif hasattr(bio, "read") and hasattr(bio, "__sizeof__"):
+            # Allow objet type which has read() and length methods for duck typing
             size = bio.__sizeof__()
         else:
             raise ValueError("Wrong argument passed for bio.")

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -35,7 +35,6 @@ import queue
 import stat
 import sys
 import threading
-from time import timezone
 from typing import IO, Any, BinaryIO, Dict, List, Optional, Tuple, Union
 
 from py7zr.archiveinfo import Folder, Header, SignatureHeader

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -35,7 +35,7 @@ import queue
 import stat
 import sys
 import threading
-from typing import IO, Any, BinaryIO, Dict, List, Optional, Tuple, Union, TextIO
+from typing import IO, Any, BinaryIO, Dict, List, Optional, Tuple, Union
 
 from py7zr.archiveinfo import Folder, Header, SignatureHeader
 from py7zr.callbacks import ExtractCallback

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -917,12 +917,15 @@ class SevenZipFile(contextlib.AbstractContextManager):
         elif isinstance(bio, io.BufferedIOBase):
             size = bio.__sizeof__()
         elif isinstance(bio, io.TextIOBase):
+            # First check whether is it Text?
             raise ValueError("Unsupported file object type: please open file with Binary mode.")
-        elif hasattr(bio, "read"):
-            # Unkown objet type but it has read() method; allow duck typing
-            pass
+        elif hasattr(bio, "read") and hasattr(bio, "__len__"):
+            # Allow objet type which has read() and length methods for duck typing
+            size = len(bio)
+        elif hasattr(bio, "read") and hasattr(bio, "__sizeof__"):
+            size = bio.__sizeof__()
         else:
-            raise ValueError("Wrong argument passed as BinaryIO.")
+            raise ValueError("Wrong argument passed for bio.")
         file_info = self._make_file_info_from_name(bio, size, arcname)
         self.header.files_info.files.append(file_info)
         self.header.files_info.emptyfiles.append(file_info['emptystream'])

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -593,6 +593,18 @@ def test_compress_files_deref_loop(tmp_path):
 
 
 @pytest.mark.basic
+def test_compress_writestr(tmp_path):
+    my_filters = [{"id": py7zr.FILTER_LZMA2, "preset": py7zr.PRESET_DEFAULT}, ]
+    target = tmp_path.joinpath('target.7z')
+    data = b'this is data'
+    with py7zr.SevenZipFile(target, 'w', filters=my_filters) as archive:
+        archive.writestr(data, 'src.txt')
+    #
+    p7zip_test(tmp_path / 'target.7z')
+    libarchive_extract(tmp_path / 'target.7z', tmp_path.joinpath('tgt2'))
+
+
+@pytest.mark.basic
 def test_compress_copy(tmp_path):
     my_filters = [{'id': py7zr.FILTER_COPY}]
     tmp_path.joinpath('src').mkdir()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2,6 +2,7 @@ import binascii
 import ctypes
 import filecmp
 import hashlib
+import io
 import lzma
 import os
 import pathlib
@@ -593,7 +594,7 @@ def test_compress_files_deref_loop(tmp_path):
 
 
 @pytest.mark.basic
-def test_compress_writestr(tmp_path):
+def test_compress_writestr1(tmp_path):
     my_filters = [{"id": py7zr.FILTER_LZMA2, "preset": py7zr.PRESET_DEFAULT}, ]
     target = tmp_path.joinpath('target.7z')
     data = b'this is data'
@@ -602,6 +603,52 @@ def test_compress_writestr(tmp_path):
     #
     p7zip_test(tmp_path / 'target.7z')
     libarchive_extract(tmp_path / 'target.7z', tmp_path.joinpath('tgt2'))
+
+
+@pytest.mark.basic
+def test_compress_writestr2(tmp_path):
+    my_filters = [{"id": py7zr.FILTER_LZMA2, "preset": py7zr.PRESET_DEFAULT}, ]
+    target = tmp_path.joinpath('target.7z')
+    data = 'this is data'
+    with py7zr.SevenZipFile(target, 'w', filters=my_filters) as archive:
+        archive.writestr(data, 'src.txt')
+    #
+    p7zip_test(tmp_path / 'target.7z')
+    libarchive_extract(tmp_path / 'target.7z', tmp_path.joinpath('tgt2'))
+
+
+@pytest.mark.basic
+def test_compress_writef1(tmp_path):
+    my_filters = [{"id": py7zr.FILTER_LZMA2, "preset": py7zr.PRESET_DEFAULT}, ]
+    target = tmp_path.joinpath('target.7z')
+    data = b'this is data'
+    with py7zr.SevenZipFile(target, 'w', filters=my_filters) as archive:
+        archive.writef(io.BytesIO(data), 'src.txt')
+    #
+    p7zip_test(tmp_path / 'target.7z')
+    libarchive_extract(tmp_path / 'target.7z', tmp_path.joinpath('tgt2'))
+
+
+@pytest.mark.basic
+def test_compress_writef2(tmp_path):
+    my_filters = [{"id": py7zr.FILTER_LZMA2, "preset": py7zr.PRESET_DEFAULT}, ]
+    target = tmp_path.joinpath('target.7z')
+    with open(os.path.join(testdata_path, "test1.txt"), 'rb') as src:
+        with py7zr.SevenZipFile(target, 'w', filters=my_filters) as archive:
+            archive.writef(src, 'test1.txt')
+    #
+    p7zip_test(tmp_path / 'target.7z')
+    libarchive_extract(tmp_path / 'target.7z', tmp_path.joinpath('tgt2'))
+
+
+@pytest.mark.basic
+def test_compress_writef3(tmp_path):
+    my_filters = [{"id": py7zr.FILTER_LZMA2, "preset": py7zr.PRESET_DEFAULT}, ]
+    target = tmp_path.joinpath('target.7z')
+    with pytest.raises(ValueError):
+        with open(os.path.join(testdata_path, "test1.txt"), 'r') as src:
+            with py7zr.SevenZipFile(target, 'w', filters=my_filters) as archive:
+                archive.writef(src, 'test1.txt')
 
 
 @pytest.mark.basic


### PR DESCRIPTION
Implement a feature request #248 and #290  

- writestr(str_or_bytes, arcname: str) accept str or bytes family data for compression.
  when receiving str as argument, it encode it into UTF-8  
- writef(BytesIO_or_binary_fileobject, arcname: str) accept io.BytesIO() memory buffer or file object with open(mode='rb')

Signed-off-by: Hiroshi Miura <miurahr@linux.com>