### PR TITLE
CI: change benchmark output format

### DIFF
--- a/utils/bench_result.py
+++ b/utils/bench_result.py
@@ -20,17 +20,29 @@ def generate_metainfo(root: dict) -> str:
 
 
 def generate_table(benchmarks: dict, group: str, type='simple') -> str:
+    base = 1
+    for bm in benchmarks:
+        if group == bm['group']:
+            if bm['params']['name'] == 'lzma2+bcj':
+                base = bm['extra_info']['rate'] / 1000000
+                if base < 0.1:
+                    base = 0.1
     table = []
     for bm in benchmarks:
         if group == bm['group']:
             target = bm['params']['name']
             rate = bm['extra_info']['rate'] / 1000000
-            ratio = bm['extra_info']['ratio']
+            if rate < 10:
+                rate = round(rate, 2)
+            else:
+                rate = round(rate, 1)
+            ratex = 'x {}'.format(round(rate / base, 2))
+            ratio = round(float(bm['extra_info']['ratio']) * 100, 1)
             min = bm['stats']['min']
             max = bm['stats']['max']
             avr = bm['stats']['mean']
-            table.append([target, rate, ratio, min, max, avr])
-    return tabulate(table, headers=['target', 'rate(MB/sec)', 'ratio', 'min(sec)', 'max(sec)', 'mean(sec)'],
+            table.append([target, rate, ratex, ratio, min, max, avr])
+    return tabulate(table, headers=['target', 'speed(MB/sec)', 'rate', 'ratio(%)', 'min(sec)', 'max(sec)', 'mean(sec)'],
                     tablefmt=type)
 
 


### PR DESCRIPTION
- change label from rate to speed
- add rate of speed compared between filters
- round results
- change ratio to %-tile

Signed-off-by: Hiroshi Miura <miurahr@linux.com>