### PR TITLE
stick pyppmd version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
       pycryptodome
       importlib_metadata;python_version<"3.8"
       pyzstd>=0.14.4,<0.15.0
-      pyppmd>=0.12.1
+      pyppmd>=0.12.1,<0.13.0
       bcj-cffi>=0.5.1,<0.6.0
       multivolumefile>=0.2.0,<0.3.0
 setup_requires =


### PR DESCRIPTION
pyppmd is still in active development and alpha version, so it will be changed drastically.
To protect from defeat, sticking PyPPMd version to 0.12.x