### PR TITLE
Set minimum pycryptodome version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ classifiers =
 python_requires = >= 3.6
 install_requires =
       texttable
-      pycryptodome
+      pycryptodome>=3.6.6
       importlib_metadata;python_version<"3.8"
       pyzstd>=0.14.4,<0.15.0
       pyppmd>=0.12.1,<0.13.0


### PR DESCRIPTION
Older version does not accept memoryview, Ref #328

Signed-off-by: Hiroshi Miura <miurahr@linux.com>