### PR TITLE
Change depends PyCryptodomex to avoid PyCrypto conflict

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -307,20 +307,23 @@ Dependencies
 
 There are several dependencies to support algorithms and CLI expressions.
 
-================  ================================
-Package           Purpose
-================  ================================
-`Pycryptodome`_   7zAES encryption
-`pyppmd`_         PPMd compression
-`bcj-cffi`_       BCJ filter
-`pyzstd`_         ZStandard compression
-`texttable`_      CLI
-================  ================================
+================== ================================
+Package            Purpose
+================== ================================
+`Pycryptodomex`_   7zAES encryption
+`PyZstd`_          ZStandard compression
+`PyPPMd`_          PPMd compression
+`bcj-cffi`_        BCJ filter
+`multivolumefile`_ Multi-volume archive read/write
+`texttable`_       CLI formatter
+================== ================================
 
-.. _`Pycryptodome` : https://pypi.org/project/pycryptodome/
-.. _`pyppmd` : https://pypi.org/project/pyppmd/
-.. _`bcj-cffi` : https://pypi.org/project/bcj-cffi/
-.. _`pyzstd` : https://pypi.org/project/pyzstd
+
+.. _`Pycryptodomex` : https://www.pycryptodome.org/en/latest/index.html
+.. _`PyZstd` : https://pypi.org/project/pyzstd
+.. _`PyPPMd` : https://pypi.org/project/pyppmd
+.. _`bcj-cffi` : https://pypi.org/project/bcj-cffi
+.. _`multivolumefile` : https://pypi.org/project/multivolumefile
 .. _`texttable` : https://pypi.org/project/texttable
 
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -23,6 +23,34 @@ using standard 'pip' command as like follows;
 
     $ pip install py7zr
 
+The py7zr depends on several external libraries. You should install these libraries with py7zr.
+There are ``PyCryptodome``, ``PyZstd``, ``PyPPMd``, ``bcj-cffi``, ``texttable``, and ``multivolumefile``.
+These pakcages are automatically installed when installing with ``pip`` command.
+
+Dependencies
+------------
+
+There are several dependencies to support algorithms and CLI expressions.
+
+================== ===============================
+Package            Purpose
+================== ===============================
+`PyCryptodomex`_   7zAES encryption
+`PyZstd`_          ZStandard compression
+`PyPPMd`_          PPMd compression
+`bcj-cffi`_        BCJ filters
+`multivolumefile`_ Multi-volume archive read/write
+`texttable`_       CLI formatter
+================== ===============================
+
+.. _`PyCryptodomex` : https://www.pycryptodome.org/en/latest/index.html
+.. _`PyZstd` : https://pypi.org/project/pyzstd
+.. _`PyPPMd` : https://pypi.org/project/pyppmd
+.. _`bcj-cffi` : https://pypi.org/project/bcj-cffi
+.. _`multivolumefile` : https://pypi.org/project/multivolumefile
+.. _`texttable` : https://pypi.org/project/texttable
+
+
 
 Run Command
 -----------

--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -31,8 +31,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pyppmd
 import pyzstd
-from Crypto.Cipher import AES
-from Crypto.Random import get_random_bytes
+from Cryptodome.Cipher import AES
+from Cryptodome.Random import get_random_bytes
 
 from py7zr.exceptions import PasswordRequired, UnsupportedCompressionMethodError
 from py7zr.helpers import Buffer, calculate_crc32, calculate_key

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ classifiers =
 python_requires = >= 3.6
 install_requires =
       texttable
-      pycryptodome>=3.6.6
+      pycryptodomex>=3.6.6
       importlib_metadata;python_version<"3.8"
       pyzstd>=0.14.4,<0.15.0
       pyppmd>=0.14.0

--- a/tests/test_extra_codecs.py
+++ b/tests/test_extra_codecs.py
@@ -4,7 +4,7 @@ import pathlib
 import zlib
 
 import pytest
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 
 import py7zr
 import py7zr.compressor


### PR DESCRIPTION
- Cygwin might have old PyCrypto that cause conflict with PyCryptodome(#328)

Signed-off-by: Hiroshi Miura <miurahr@linux.com>