### PR TITLE
Default exceptions to include the exceptions type

### DIFF
--- a/py7zr/exceptions.py
+++ b/py7zr/exceptions.py
@@ -23,7 +23,9 @@
 
 
 class ArchiveError(Exception):
-    pass
+    def __init__(self, *args, **kwargs):
+        if not args and not kwargs:
+            super().__init__(type(self))
 
 
 class Bad7zFile(ArchiveError):


### PR DESCRIPTION
Currently any exception raised by the library, when printed, will just print a '\n'. 
This makes debugging difficult as if you print the exceptions you see nothing. 
For example the following code
```
import py7zr 

try:
    print("Raising")
    raise py7zr.exceptions.UnsupportedCompressionMethodError
except py7zr.exceptions.UnsupportedCompressionMethodError as e:
    print(e)
    print(str(e))
    
print("Done")
```
Outputs
```
Raising


Done
```



The changes in this merge will print the name of the exception so after this merge the above code would print
```
Raising
<class 'py7zr.exceptions.UnsupportedCompressionMethodError'>
<class 'py7zr.exceptions.UnsupportedCompressionMethodError'>
Done
```
Which while not brilliant is still an improvement 
I have checked that this change doesn't break code which raises with an error string so the following code still works as expected
```
import py7zr 

try:
    print("Raising")
    raise py7zr.exceptions.UnsupportedCompressionMethodError("foobar")
except py7zr.exceptions.UnsupportedCompressionMethodError as e:
    print(e)
    print(str(e))
    
print("Done")
```
       
Output
```
Raising
foobar
foobar
Done
```

Thank you :)

 