### PR TITLE
Return created archive name to conform with shutil API

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -1133,9 +1133,9 @@ def unpack_7zarchive(archive, path, extra=None):
 def pack_7zarchive(base_name, base_dir, owner=None, group=None, dry_run=None, logger=None):
     """Function for registering with shutil.register_archive_format()"""
     target_name = "{}.7z".format(base_name)
-    archive = SevenZipFile(target_name, mode="w")
-    archive.writeall(path=base_dir)
-    archive.close()
+    with SevenZipFile(target_name, mode="w") as archive:
+        archive.writeall(path=base_dir)
+    return target_name
 
 
 class Worker:


### PR DESCRIPTION
shutil.make_archive documented as
> Returns the name of the archive file.

and using py7zr currently breaks code relying on returned value.