### PR TITLE
Fix typo in docs about shutil integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,7 +238,7 @@ py7zr also support `shutil`  interface.
 
 .. code-block:: python
 
-    from py7zr import pack_7zarchvie, unpack_7zarchive
+    from py7zr import pack_7zarchive, unpack_7zarchive
     import shutil
 
     # register file format at first.


### PR DESCRIPTION
Make it copypaste-ready.