### PR TITLE
Fix infinite loop in SevenZipFile._extract

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -538,6 +538,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
                     outname = f.filename + "_%d" % i
                     if outname not in fnames:
                         break
+                    i += 1
             fnames.append(outname)
             if path is not None:
                 outfilename = path.joinpath(outname)


### PR DESCRIPTION
Fixes hanging if an archive contains two files with the same CRC (for some reason). I don't quite get how it fixes that bug, but adding this line seems like it was the intended behaviour nonetheless.