### PR TITLE
Improve error messages for callback feature

### DIFF
--- a/py7zr/callbacks.py
+++ b/py7zr/callbacks.py
@@ -2,7 +2,7 @@
 #
 # p7zr library
 #
-# Copyright (c) 2020 Hiroshi Miura <miurahr@linux.com>
+# Copyright (c) 2020,2021 Hiroshi Miura <miurahr@linux.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 
 
 class Callback(ABC):
-    """Abstrat base class for progress callbacks."""
+    """Abstract base class for progress callbacks."""
 
     @abstractmethod
     def report_start_preparation(self):
@@ -52,12 +52,12 @@ class Callback(ABC):
 
 
 class ExtractCallback(Callback):
-    """Abstrat base class for extraction progress callbacks."""
+    """Abstract base class for extraction progress callbacks."""
 
     pass
 
 
 class ArchiveCallback(Callback):
-    """Abstrat base class for progress callbacks."""
+    """Abstract base class for progress callbacks."""
 
     pass

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -517,7 +517,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
             else:
                 raise ValueError(
                     "Callback specified is not an instance of subclass of py7zr.callbacks.ExtractCallback class"
-                    )
+                )
         except:
             raise TypeError("Callback is not an instance but class, or unknown object")
         target_files: List[Tuple[pathlib.Path, Dict[str, Any]]] = []

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -513,9 +513,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
             self.reporterd = Thread(target=self.reporter, args=(callback,), daemon=True)
             self.reporterd.start()
         else:
-            raise ValueError(
-                "Callback specified is not an instance of subclass of py7zr.callbacks.ExtractCallback class"
-            )
+            raise ValueError("Callback specified is not an instance of subclass of py7zr.callbacks.ExtractCallback class")
         target_files: List[Tuple[pathlib.Path, Dict[str, Any]]] = []
         target_dirs: List[pathlib.Path] = []
         if path is not None:

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -23,6 +23,7 @@
 #
 #
 """Read 7zip format archives."""
+import abc
 import collections.abc
 import contextlib
 import datetime
@@ -507,11 +508,18 @@ class SevenZipFile(contextlib.AbstractContextManager):
         return_dict: bool = False,
         callback: Optional[ExtractCallback] = None,
     ) -> Optional[Dict[str, IO[Any]]]:
-        if callback is not None and not isinstance(callback, ExtractCallback):
-            raise ValueError("Callback specified is not a subclass of py7zr.callbacks.ExtractCallback class")
-        elif callback is not None:
-            self.reporterd = Thread(target=self.reporter, args=(callback,), daemon=True)
-            self.reporterd.start()
+        try:
+            if callback is None:
+                pass
+            elif isinstance(callback, ExtractCallback):
+                self.reporterd = Thread(target=self.reporter, args=(callback,), daemon=True)
+                self.reporterd.start()
+            else:
+                raise ValueError(
+                    "Callback specified is not an instance of subclass of py7zr.callbacks.ExtractCallback class"
+                    )
+        except:
+            raise TypeError("Callback is not an instance but class, or unknown object")
         target_files: List[Tuple[pathlib.Path, Dict[str, Any]]] = []
         target_dirs: List[pathlib.Path] = []
         if path is not None:

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -23,7 +23,6 @@
 #
 #
 """Read 7zip format archives."""
-import abc
 import collections.abc
 import contextlib
 import datetime
@@ -508,18 +507,15 @@ class SevenZipFile(contextlib.AbstractContextManager):
         return_dict: bool = False,
         callback: Optional[ExtractCallback] = None,
     ) -> Optional[Dict[str, IO[Any]]]:
-        try:
-            if callback is None:
-                pass
-            elif isinstance(callback, ExtractCallback):
-                self.reporterd = Thread(target=self.reporter, args=(callback,), daemon=True)
-                self.reporterd.start()
-            else:
-                raise ValueError(
-                    "Callback specified is not an instance of subclass of py7zr.callbacks.ExtractCallback class"
-                )
-        except:
-            raise TypeError("Callback is not an instance but class, or unknown object")
+        if callback is None:
+            pass
+        elif isinstance(callback, ExtractCallback):
+            self.reporterd = Thread(target=self.reporter, args=(callback,), daemon=True)
+            self.reporterd.start()
+        else:
+            raise ValueError(
+                "Callback specified is not an instance of subclass of py7zr.callbacks.ExtractCallback class"
+            )
         target_files: List[Tuple[pathlib.Path, Dict[str, Any]]] = []
         target_dirs: List[pathlib.Path] = []
         if path is not None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -673,32 +673,6 @@ def test_context_manager_2(tmp_path):
 
 
 @pytest.mark.api
-def test_extract_callback(tmp_path):
-    class ECB(py7zr.callbacks.ExtractCallback):
-        def __init__(self, ofd):
-            self.ofd = ofd
-
-        def report_start_preparation(self):
-            self.ofd.write("preparation.\n")
-
-        def report_start(self, processing_file_path, processing_bytes):
-            self.ofd.write('start "{}" (compressed in {} bytes)\n'.format(processing_file_path, processing_bytes))
-
-        def report_end(self, processing_file_path, wrote_bytes):
-            self.ofd.write('end "{}" extracted to {} bytes\n'.format(processing_file_path, wrote_bytes))
-
-        def report_postprocess(self):
-            self.ofd.write("post processing.\n")
-
-        def report_warning(self, message):
-            self.ofd.write("warning: {:s}\n".format(message))
-
-    cb = ECB(sys.stdout)
-    with py7zr.SevenZipFile(open(os.path.join(testdata_path, "test_1.7z"), "rb")) as archive:
-        archive.extractall(path=tmp_path, callback=cb)
-
-
-@pytest.mark.api
 def test_py7zr_list_values():
     with py7zr.SevenZipFile(os.path.join(testdata_path, "test_1.7z"), "r") as z:
         file_list = z.list()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -109,7 +109,7 @@ class callback(py7zr.callbacks.ExtractCallback):
 
 def test_callback_raw_class():
     # test the case when passed argument is class name.
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         with py7zr.SevenZipFile(testdata_path.joinpath("solid.7z").open(mode="rb")) as z:
             z.extractall(None, callback)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -100,3 +100,12 @@ def test_double_extract_symlink(tmp_path):
         archive.extractall(path=tmp_path)
     with py7zr.SevenZipFile(testdata_path.joinpath("symlink_2.7z").open(mode="rb")) as archive:
         archive.extractall(path=tmp_path)
+
+
+class callback( py7zr.callbacks.ExtractCallback):
+    def __init__(self):
+        pass
+
+def test_callback_issue_386():
+    with py7zr.SevenZipFile(testdata_path.joinpath("solid.7z").open(mode="rb")) as z:
+        z.extractall(None,  callback)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -102,15 +102,16 @@ def test_double_extract_symlink(tmp_path):
         archive.extractall(path=tmp_path)
 
 
-class callback( py7zr.callbacks.ExtractCallback):
+class callback(py7zr.callbacks.ExtractCallback):
     def __init__(self):
         pass
+
 
 def test_callback_raw_class():
     # test the case when passed argument is class name.
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(testdata_path.joinpath("solid.7z").open(mode="rb")) as z:
-            z.extractall(None,  callback)
+            z.extractall(None, callback)
 
 
 def test_callback_not_concrete_class():
@@ -118,7 +119,7 @@ def test_callback_not_concrete_class():
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(testdata_path.joinpath("solid.7z").open(mode="rb")) as z:
             cb = callback()
-            z.extractall(None,  cb)
+            z.extractall(None, cb)
 
 
 @pytest.mark.api

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -106,6 +106,43 @@ class callback( py7zr.callbacks.ExtractCallback):
     def __init__(self):
         pass
 
-def test_callback_issue_386():
-    with py7zr.SevenZipFile(testdata_path.joinpath("solid.7z").open(mode="rb")) as z:
-        z.extractall(None,  callback)
+def test_callback_raw_class():
+    # test the case when passed argument is class name.
+    with pytest.raises(TypeError):
+        with py7zr.SevenZipFile(testdata_path.joinpath("solid.7z").open(mode="rb")) as z:
+            z.extractall(None,  callback)
+
+
+def test_callback_not_concrete_class():
+    # test the case when passed arugment is abstract class
+    with pytest.raises(TypeError):
+        with py7zr.SevenZipFile(testdata_path.joinpath("solid.7z").open(mode="rb")) as z:
+            cb = callback()
+            z.extractall(None,  cb)
+
+
+@pytest.mark.api
+def test_extract_callback(tmp_path):
+    # test the case when good callback passed.
+    class ECB(py7zr.callbacks.ExtractCallback):
+        def __init__(self, ofd):
+            self.ofd = ofd
+
+        def report_start_preparation(self):
+            self.ofd.write("preparation.\n")
+
+        def report_start(self, processing_file_path, processing_bytes):
+            self.ofd.write('start "{}" (compressed in {} bytes)\n'.format(processing_file_path, processing_bytes))
+
+        def report_end(self, processing_file_path, wrote_bytes):
+            self.ofd.write('end "{}" extracted to {} bytes\n'.format(processing_file_path, wrote_bytes))
+
+        def report_postprocess(self):
+            self.ofd.write("post processing.\n")
+
+        def report_warning(self, message):
+            self.ofd.write("warning: {:s}\n".format(message))
+
+    cb = ECB(sys.stdout)
+    with py7zr.SevenZipFile(open(os.path.join(testdata_path, "test_1.7z"), "rb")) as archive:
+        archive.extractall(path=tmp_path, callback=cb)


### PR DESCRIPTION
- Raising TypeError when passing class not instance
- Improve error messages when wrong callback argument passed
- Reproduce a behavior of  #386
- Put callback basic test in next of error test

Signed-off-by: Hiroshi Miura <miurahr@linux.com>