### PR TITLE
azure: bump macos@10.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'macOS-10.14'
+  vmImage: 'macOS-10.15'
 
 strategy:
   matrix:


### PR DESCRIPTION
- macos 10.14 will be deprecated on azure pipeline in dec. 2021

Signed-off-by: Hiroshi Miura <miurahr@linux.com>