### PR TITLE
Remove check for `__sizeof__` in `SevenZipFile.writef`

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -1013,11 +1013,6 @@ class SevenZipFile(contextlib.AbstractContextManager):
         elif isinstance(bio, io.TextIOBase):
             # First check whether is it Text?
             raise ValueError("Unsupported file object type: please open file with Binary mode.")
-        elif hasattr(bio, "read") and hasattr(bio, "__sizeof__"):
-            # CPython's io.BufferedIOBase or io.BufferedReader has __sizeof__, but
-            # pypy3 don't have. So first check __sizeof__ and then goes to alternative.
-            # Also allowing objet type which has read() and length methods for duck typing
-            size = bio.__sizeof__()
         elif isinstance(bio, io.BufferedIOBase):
             # come here when subtype of io.BufferedIOBase that don't have __sizeof__ (eg. pypy)
             # alternative for `size = bio.__sizeof__()`


### PR DESCRIPTION
Hi!

I recently started using `py7zr` in [`fs.archive`](https://github.com/althonos/fs.archive) to allow reading 7zip archives using the [PyFilesystem2](https://github.com/PyFilesystem/pyfilesystem2), and it works super well, so congrats!

One of the things I noticed when reading the code was this snippet I removed here, which was erroneously using the `__sizeof__` magic method. Basically, this method can be used by object to provide for their *allocated* size, not for the size of their content as a readable object. For instance, if I open two different files on my computer, `__sizeof__` will return the size of the `io.BufferedReader` object, not the size in bytes of the file. This would be an error here and cause the wrong number of bytes to be compressed.

(also: to check for the allocated size of an object, it would be advised to use [`sys.getsizeof`](https://docs.python.org/3/library/sys.html#sys.getsizeof) instead of calling `__sizeof__` directly :wink: )