### PR TITLE
Update README: add experimental for PPMd method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -307,8 +307,8 @@ Supported algorithms are:
     * Bzip2
     * Deflate
     * Copy
-    * PPMd
     * ZStandard
+    * PPMd (Experimental)
     * Brotli
 
 * crypt


### PR DESCRIPTION
Due to #417 PPMd decompression failed constantly.
This put "(experimental)" for PPMd to notify that it is not stable.