### PR TITLE
Decompress: limit memory consumptions

### DIFF
--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -74,6 +74,29 @@ jobs:
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: py-${{ matrix.python-version }}-${{ matrix.os }}
 
+  test_slow_tests:
+    name: Test slow test cases
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: x64
+      - name: Install system library(linux)
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -q -y libarchive-dev
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install tox tox-gh-actions
+      - name: Test project with tox
+        run: tox
+        env:
+          PYTEST_ADDOPTS: "--no-cov --run-slow -k extract_high_compression_rate"
+
   test_on_aarch64:
     name: Test on ${{ matrix.arch }}
     runs-on: ubuntu-20.04

--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -628,10 +628,7 @@ class SevenZipDecompressor:
     def _decompress(self, data, max_length: int):
         for i, decompressor in enumerate(self.chain):
             if self._unpacked[i] < self._unpacksizes[i]:
-                if isinstance(decompressor, LZMA1Decompressor) or isinstance(decompressor, PpmdDecompressor):
-                    data = decompressor.decompress(data, max_length)  # always give max_length for lzma1
-                else:
-                    data = decompressor.decompress(data)
+                data = decompressor.decompress(data, max_length)
                 self._unpacked[i] += len(data)
             elif len(data) == 0:
                 data = b""

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -46,7 +46,7 @@ from py7zr.callbacks import ExtractCallback
 from py7zr.compressor import SupportedMethods, get_methods_names
 from py7zr.exceptions import Bad7zFile, CrcError, DecompressionError, InternalError, UnsupportedCompressionMethodError
 from py7zr.helpers import ArchiveTimestamp, MemIO, NullIO, calculate_crc32, filetime_to_dt, readlink
-from py7zr.properties import DEFAULT_FILTERS, MAGIC_7Z, get_default_blocksize, FILTER_DEFLATE64
+from py7zr.properties import DEFAULT_FILTERS, FILTER_DEFLATE64, MAGIC_7Z, get_default_blocksize, get_memory_limit
 from py7zr.win32compat import is_windows_native_python, is_windows_unc_path
 
 if sys.platform.startswith("win"):
@@ -1379,10 +1379,11 @@ class Worker:
         """
         assert folder is not None
         out_remaining = size
+        max_block_size = get_memory_limit()
         crc32 = 0
         decompressor = folder.get_decompressor(compressed_size)
         while out_remaining > 0:
-            tmp = decompressor.decompress(fp, out_remaining)
+            tmp = decompressor.decompress(fp, min(out_remaining, max_block_size))
             if len(tmp) > 0:
                 out_remaining -= len(tmp)
                 fq.write(tmp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
       'importlib_metadata;python_version<"3.8"',
       'brotli>=1.0.9;platform_python_implementation=="CPython"',
       'brotlicffi>=1.0.9.2;platform_python_implementation=="PyPy"',
+      "psutil",
       "pyzstd>=0.14.4",
       "pyppmd>=0.18.1,<0.19.0",
       'pybcj>=0.5.0;platform_python_implementation=="CPython"',
@@ -139,6 +140,7 @@ markers = [
     "cli: mark a test as a cli test.",
     "benchmark: mark a test as a benchmarking.",
     "misc: misc tests",
+    "slow: mark a slow tests",
 ]
 
 [tool.tox]

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
       importlib_metadata;python_version<"3.8"
       brotli>=1.0.9;platform_python_implementation=="CPython"
       brotlicffi>=1.0.9.2;platform_python_implementation=="PyPy"
+      psutil
       pyzstd>=0.14.4
       pyppmd>=0.18.1,<0.19.0
       pybcj>=0.5.0;platform_python_implementation=="CPython"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,3 +43,17 @@ def pytest_benchmark_update_machine_info(config, machine_info):
         brand = "{} core(s) {} CPU ".format(cpu_info.get("count", "unknown"), cpu_info.get("arch", "unknown"))
     machine_info["cpu"]["brand"] = brand
     machine_info["cpu"]["hz_actual_friendly"] = cpu_info.get("hz_actual_friendly", "unknown")
+
+
+def pytest_addoption(parser):
+    parser.addoption("--run-slow", action="store_true", default=False, help="run slow tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-slow"):
+        # --run-slow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --run-slow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)


### PR DESCRIPTION
Reproduce the case and resolve #430

* Add test case to reproduce memory error
* Always pass mem_length for decpmpressor.decompress to limit chunk size
* Detect available memory size to limit decompress chunk size
* Limit maximum chunk size to 512MB.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>