### PR TITLE
Fix pyproject.toml:license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "py7zr"
 requires-python = ">=3.6"
 description = "Pure python 7-zip library"
 readme = "README.rst"
-license = {file = "LICENSE"}
+license = {text = "LGPL-2.1-or-later"}
 authors = [
     {name = "Hiroshi Miura", email = "miurahr@linux.com"},
 ]


### PR DESCRIPTION
- Specify license text with its name instead of file key.
- PyPI index try to include all license text from file, that cause overflow the index page.
- Resolve #435

Signed-off-by: Hiroshi Miura <miurahr@linux.com>