### PR TITLE
Change deflate64 support as optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,10 @@ Supported algorithms
     but not work with original 7-zip because the original does not implement the feature.
   * ZStandard and Brotli is not default methods of 7-zip, so these archives are considered
     not to be compatible with original 7-zip on windows/p7zip on linux/mac.
+  * Deflate64 is optional codec. You need to install extension ``deflate64`` when install py7zr
+    like ``pip install py7zr[deflate64]``. Because a deflate64 library is provided only
+    for 64bit systems, you may get install error when using 32bit systems.
+
 
 Not supported algorithms
 ------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
       "pyppmd>=0.18.1,<0.19.0",
       "pybcj>=0.6.0",
       "multivolumefile>=0.2.3",
-      "zipfile-deflate64>=0.2.0",
 ]
 keywords = ['compression', '7zip', 'lzma', 'zstandard', 'ppmd', 'lzma2', 'bcj', 'archive']
 dynamic = ["version", "entry-points"]
@@ -46,6 +45,7 @@ dynamic = ["version", "entry-points"]
 py7zr = "py7zr.__main__:main"
 
 [project.optional-dependencies]
+deflate64 = ["zipfile-deflate64>=0.2.0"]
 test_compat = ["libarchive-c"]
 test = [
       "pytest",
@@ -178,10 +178,10 @@ depends =
     pypy3,py{36,37,38,39,310}: clean, check
 
 [testenv:py38]
-extras = test, test_compat
+extras = test, test_compat, deflate64
 
 [testenv:pypy3]
-extras = test, test_compat
+extras = test, test_compat, deflate64
 
 [testenv:mprof]
 extras = test, debug

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ install_requires =
       pyppmd>=0.18.1,<0.19.0
       pybcj>=0.6.0
       multivolumefile>=0.2.3
-      zipfile-deflate64>=0.2.0
 setup_requires =
       setuptools-scm>=6.0.1
       wheel
@@ -63,6 +62,7 @@ console_scripts =
 * = py7zr/py.typed
 
 [options.extras_require]
+deflate64 = zipfile-deflate64>=0.2.0
 test_compat = libarchive-c
 test =
       pytest

--- a/tests/test_extra_codecs.py
+++ b/tests/test_extra_codecs.py
@@ -11,6 +11,7 @@ import py7zr.compressor
 from py7zr import UnsupportedCompressionMethodError
 from py7zr.properties import FILTER_DEFLATE64
 from tests import p7zip_test
+
 try:
     from zipfile_deflate64 import deflate64  # type: ignore
 except ImportError:

--- a/tests/test_extra_codecs.py
+++ b/tests/test_extra_codecs.py
@@ -11,6 +11,10 @@ import py7zr.compressor
 from py7zr import UnsupportedCompressionMethodError
 from py7zr.properties import FILTER_DEFLATE64
 from tests import p7zip_test
+try:
+    from zipfile_deflate64 import deflate64  # type: ignore
+except ImportError:
+    deflate64 = None
 
 testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
 os.umask(0o022)
@@ -285,6 +289,7 @@ def test_compress_deflate64(tmp_path):
 
 
 @pytest.mark.basic
+@pytest.mark.skipif(deflate64 is None, reason="deflate64 extension is not installed.")
 def test_decompress_deflate64(tmp_path):
     with py7zr.SevenZipFile(testdata_path.joinpath("deflate64.7z").open(mode="rb")) as archive:
         archive.extractall(path=tmp_path.joinpath("tgt"))

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -4,6 +4,10 @@ import pytest
 
 import py7zr
 from py7zr.exceptions import UnsupportedCompressionMethodError
+try:
+    from zipfile_deflate64 import deflate64  # type: ignore
+except ImportError:
+    deflate64 = None
 
 testdata_path = os.path.join(os.path.dirname(__file__), "data")
 os.umask(0o022)
@@ -93,6 +97,7 @@ def test_archivetest_deflate():
 
 
 @pytest.mark.files
+@pytest.mark.skipif(deflate64 is None, reason="deflate64 extension is not installed.")
 def test_archivetest_deflate64():
     with py7zr.SevenZipFile(os.path.join(testdata_path, "deflate64.7z"), "r") as ar:
         assert ar.testzip() is None

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -4,6 +4,7 @@ import pytest
 
 import py7zr
 from py7zr.exceptions import UnsupportedCompressionMethodError
+
 try:
     from zipfile_deflate64 import deflate64  # type: ignore
 except ImportError:


### PR DESCRIPTION
Dependency zipfile-deflate64 wheels are provided only for 64bit systems.
It causes an install error on 32bit systems.
This ask user who want to use deflate64 decompression to install extension deflate64.

workaround for #455 

Signed-off-by: Hiroshi Miura <miurahr@linux.com>