### PR TITLE
Switch deflate64 decompressor to inflate64

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Supported algorithms
     * Copy
     * ZStandard
     * Brotli
-    * Deflate64 (Decompression only)
+    * Deflate64 (Decompression only, python 3.7 or later)
     * PPMd (Experimental)
 
 * crypt
@@ -73,6 +73,8 @@ Supported algorithms
     but not work with original 7-zip because the original does not implement the feature.
   * ZStandard and Brotli is not default methods of 7-zip, so these archives are considered
     not to be compatible with original 7-zip on windows/p7zip on linux/mac.
+  * Deflate64 is optional decompress only codec that available for python 3.7 or later.
+
 
 Not supported algorithms
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -354,7 +354,7 @@ Package               Purpose
 `PyPPMd`_             PPMd compression
 `Brotli`_             Brotli compression (CPython)
 `BrotliCFFI`_         Brotli compression (PyPy)
-`zipfile-deflate64`_  DEFLATE64 decompression
+`inflate64`_          DEFLATE64 decompression
 `pybcj`_              BCJ filters
 `multivolumefile`_    Multi-volume archive read/write
 `texttable`_          CLI formatter
@@ -366,7 +366,7 @@ Package               Purpose
 .. _`PyPPMd` : https://pypi.org/project/pyppmd
 .. _`Brotli` : https://pypi.org/project/brotli
 .. _`BrotliCFFI` : https://pypi.org/project/brotlicffi
-.. _`zipfile-deflate64` : https://github.com/brianhelba/zipfile-deflate64
+.. _`inflate64` : https://pypi.org/project/inflate64
 .. _`pybcj` : https://pypi.org/project/pybcj
 .. _`multivolumefile` : https://pypi.org/project/multivolumefile
 .. _`texttable` : https://pypi.org/project/texttable

--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -66,9 +66,9 @@ try:
 except ImportError:
     import brotlicffi as brotli  # type: ignore  # noqa
 try:
-    import inflate64  # type: ignore
+    import inflate64  # noqa
 except ImportError:
-    inflate64 = None
+    inflate64 = None  # type: ignore  # noqa
 brotli_major = 1
 brotli_minor = 0
 

--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -32,7 +32,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import bcj  # type: ignore  # noqa
 import pyppmd
 import pyzstd
-from zipfile_deflate64 import deflate64  # type: ignore
 from Cryptodome.Cipher import AES
 from Cryptodome.Random import get_random_bytes
 
@@ -66,6 +65,10 @@ try:
     import brotli  # type: ignore  # noqa
 except ImportError:
     import brotlicffi as brotli  # type: ignore  # noqa
+try:
+    import inflate64  # type: ignore
+except ImportError:
+    inflate64 = None
 brotli_major = 1
 brotli_minor = 0
 
@@ -268,16 +271,22 @@ class Deflate64Compressor(ISevenZipCompressor):
 class Deflate64Decompressor(ISevenZipDecompressor):
     def __init__(self):
         self.flushed = False
-        self._decompressor = deflate64.Deflate64()
+        if inflate64 is not None:
+            self._decompressor = inflate64.Inflater()
+            self._enabled = True
+        else:
+            self._enabled = False
 
     def decompress(self, data: Union[bytes, bytearray, memoryview], max_length: int = -1) -> bytes:
+        if not self._enabled:
+            raise UnsupportedCompressionMethodError(None, "inflate64 is not installed.")
         if len(data) == 0:
             if self.flushed:
                 return b""
             else:
                 self.flushed = True
-                return self._decompressor.flush()
-        return self._decompressor.decompress(data)
+                return self._decompressor.inflate(b"")
+        return self._decompressor.inflate(data)
 
 
 class CopyCompressor(ISevenZipCompressor):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
       "pyppmd>=0.18.1,<0.19.0",
       "pybcj>=0.6.0",
       "multivolumefile>=0.2.3",
-      "zipfile-deflate64>=0.2.0",
+      'inflate64>=0.1.2;python_version>"3.6"',
 ]
 keywords = ['compression', '7zip', 'lzma', 'zstandard', 'ppmd', 'lzma2', 'bcj', 'archive']
 dynamic = ["version", "entry-points"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
       pyppmd>=0.18.1,<0.19.0
       pybcj>=0.6.0
       multivolumefile>=0.2.3
-      zipfile-deflate64>=0.2.0
+      inflate64>=0.1.2;python_version>"3.6"
 setup_requires =
       setuptools-scm>=6.0.1
       wheel

--- a/tests/test_extra_codecs.py
+++ b/tests/test_extra_codecs.py
@@ -12,6 +12,11 @@ from py7zr import UnsupportedCompressionMethodError
 from py7zr.properties import FILTER_DEFLATE64
 from tests import p7zip_test
 
+try:
+    import inflate64  # type: ignore
+except ImportError:
+    inflate64 = None
+
 testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
 os.umask(0o022)
 
@@ -285,6 +290,7 @@ def test_compress_deflate64(tmp_path):
 
 
 @pytest.mark.basic
+@pytest.mark.skipif(inflate64 is None, reason="inflate64 is not installed.")
 def test_decompress_deflate64(tmp_path):
     with py7zr.SevenZipFile(testdata_path.joinpath("deflate64.7z").open(mode="rb")) as archive:
         archive.extractall(path=tmp_path.joinpath("tgt"))

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -5,6 +5,11 @@ import pytest
 import py7zr
 from py7zr.exceptions import UnsupportedCompressionMethodError
 
+try:
+    import inflate64  # type: ignore
+except ImportError:
+    inflate64 = None
+
 testdata_path = os.path.join(os.path.dirname(__file__), "data")
 os.umask(0o022)
 
@@ -93,6 +98,7 @@ def test_archivetest_deflate():
 
 
 @pytest.mark.files
+@pytest.mark.skipif(inflate64 is None, reason="inflate64 is not installed.")
 def test_archivetest_deflate64():
     with py7zr.SevenZipFile(os.path.join(testdata_path, "deflate64.7z"), "r") as ar:
         assert ar.testzip() is None


### PR DESCRIPTION
``inflate64`` is an alternative library to decompress Deflate64(tm) (Enhanced Deflate) data **without** depending zlib/infback9 patch or lzma-sdk.
It provides wheels for all major platfroms, win, mac and linux, arm64, amd64, i686, and manylinux, musllinux, cpython and pypy.
