### PR TITLE
Fix sanity check for path traversal attack

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -7,6 +7,15 @@ All notable changes to this project will be documented in this file.
 `Unreleased`_
 =============
 
+Security
+--------
+
+* Fix sanity check for path traversal attack(#480)
+* Add path checker in writef() and writestr() methods that ignores evil pass.
+  - When pass arcname as evil path such as "../../../../tmp/evil.sh"
+  - it raises ValueError
+* Check symlink and junction is under target folder when extraction
+
 `v0.20.0`_
 ==========
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,8 +3,6 @@ include *.rst
 include *.svg
 include *.toml
 include LICENSE
-include .coveragerc
-include tox.ini
 include py7zr/py.typed
 recursive-include py7zr *.py
 recursive-include tests *.py
@@ -25,7 +23,6 @@ recursive-include docs *.yml
 recursive-include docs *.odp
 recursive-include docs *.pdf
 recursive-include docs *.svg
-recursive-include docs *.txt
 recursive-include docs Makefile
 prune .github
 exclude .gitignore

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -332,7 +332,7 @@ def test_skip():
     for i, cf in enumerate(archive.files):
         assert cf is not None
         archive.worker.register_filelike(cf.id, None)
-    archive.worker.extract(archive.fp, parallel=True)
+    archive.worker.extract(archive.fp, None, parallel=True)
     archive.close()
 
 

--- a/tests/test_zipslip.py
+++ b/tests/test_zipslip.py
@@ -1,0 +1,48 @@
+import os
+
+import pytest
+
+from py7zr import SevenZipFile
+from py7zr.exceptions import Bad7zFile
+from py7zr.helpers import check_archive_path, get_sanitized_output_path
+from py7zr.properties import FILTER_LZMA2, PRESET_DEFAULT
+
+testdata_path = os.path.join(os.path.dirname(__file__), "data")
+
+
+@pytest.mark.misc
+def test_check_archive_path():
+    bad_path = "../../.../../../../../../tmp/evil.sh"
+    assert not check_archive_path(bad_path)
+
+
+@pytest.mark.misc
+def test_get_sanitized_output_path_1(tmp_path):
+    bad_path = "../../.../../../../../../tmp/evil.sh"
+    with pytest.raises(Bad7zFile):
+        get_sanitized_output_path(bad_path, tmp_path)
+
+
+@pytest.mark.misc
+def test_get_sanitized_output_path_2(tmp_path):
+    good_path = "good.sh"
+    expected = tmp_path.joinpath(good_path)
+    assert expected == get_sanitized_output_path(good_path, tmp_path)
+
+
+@pytest.mark.misc
+def test_extract_path_traversal_attack(tmp_path):
+    my_filters = [
+        {"id": FILTER_LZMA2, "preset": PRESET_DEFAULT},
+    ]
+    target = tmp_path.joinpath("target.7z")
+    good_data = b"#!/bin/sh\necho good\n"
+    good_path = "good.sh"
+    bad_data = b"!#/bin/sh\necho bad\n"
+    bad_path = "../../.../../../../../../tmp/evil.sh"
+    with SevenZipFile(target, "w", filters=my_filters) as archive:
+        archive.writestr(good_data, good_path)
+        archive._writestr(bad_data, bad_path)  # bypass a path check
+    with pytest.raises(Bad7zFile):
+        with SevenZipFile(target, "r") as archive:
+            archive.extractall(path=tmp_path)


### PR DESCRIPTION
- Previous versions do not detect the attack in some case
   - fixed it by call resolve()
   - resolve() converts "/hoge/fuga/../../../tmp/evil.sh" to be "/tmp/evil.sh" then relative_to() can detect path traversal attack.
- Add path checker in writef() and writestr() methods
  - When pass arcname as evil path such as "../../../../tmp/evil.sh" it raises ValueError
- Add test case of bad path detection
- extraction: check symlink and junction is under target folder
- Don't put windows file namespace to output file path

Signed-off-by: Hiroshi Miura <miurahr@linux.com>