### PR TITLE
Actions: fix benchmark script

### DIFF
--- a/.github/workflows/run-benchmark.yml
+++ b/.github/workflows/run-benchmark.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.10, pypy3]
+        python-version: ['3.10', 'pypy3.7']
     name: Benchmark on Python ${{ matrix.python-version }}
     env:
       ISSUE_NUMBER: 297
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64


### PR DESCRIPTION
- Change to pypy3.7 instead of pypy3
- Bump actions/checkout@v3 and actions/setup-python@v4

Signed-off-by: Hiroshi Miura <miurahr@linux.com>