### PR TITLE
Disable enhanced deflate compression on pypy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,10 +71,12 @@ Supported algorithms
 .. note::
   * A feature handling symbolic link is basically compatible with ``p7zip`` implementation,
     but not work with original 7-zip because the original does not implement the feature.
+  * ``py7zr`` try checking symbolic links strictly and raise ValueError when bad link is requested,
+    but it does **not** guarantee to block all the bad cases.
   * ZStandard and Brotli is not default methods of 7-zip, so these archives are considered
     not to be compatible with original 7-zip on windows/p7zip on linux/mac.
   * Enhanced Deflate is also known as `DEFLATE64` :sup:`TM` that is a registered trademark of `PKWARE, Inc.`
-
+  * Enhanced Deflate is tested only on CPython. It is disabled on PyPy.
 
 Not supported algorithms
 ------------------------
@@ -317,7 +319,7 @@ It hopefully works on M1 Mac too.
 Recommended versions are:
 
 - CPython 3.7.5, CPython 3.8.0 and later.
-- PyPy3.6-7.3.2 and later.
+- PyPy3.7-7.3.3 and later.
 
 Following fixes are included in these versions, and it is not fixed on python3.6.
 

--- a/py7zr/cli.py
+++ b/py7zr/cli.py
@@ -340,11 +340,13 @@ class Cli:
         except py7zr.exceptions.PasswordRequired:
             print("The archive is encrypted, but password is not given. ABORT.")
             return 1
-        except lzma.LZMAError or _lzma.LZMAError:
+        except lzma.LZMAError:
             if password is None:
                 print("The archive is corrupted. ABORT.")
             else:
                 print("The archive is corrupted, or password is wrong. ABORT.")
+            return 1
+        except _lzma.LZMAError:
             return 1
 
         cb = None  # Optional[ExtractCallback]
@@ -365,11 +367,13 @@ class Cli:
         except py7zr.exceptions.PasswordRequired:
             print("The archive is encrypted, but password is not given. ABORT.")
             return 1
-        except lzma.LZMAError or _lzma.LZMAError:
+        except lzma.LZMAError:
             if password is None:
                 print("The archive is corrupted. ABORT.")
             else:
                 print("The archive is corrupted, or password is wrong. ABORT.")
+            return 1
+        except _lzma.LZMAError:
             return 1
         else:
             return 0

--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -272,12 +272,12 @@ class Deflate64Compressor(ISevenZipCompressor):
 
     def compress(self, data: Union[bytes, bytearray, memoryview], max_length: int = -1) -> bytes:
         if not self._enabled:
-            raise UnsupportedCompressionMethodError(None, "deflate64 compression is disabled on pypy.")
+            raise UnsupportedCompressionMethodError(None, "deflate64 is disabled on pypy.")
         return self._compressor.deflate(data)
 
     def flush(self) -> bytes:
         if not self._enabled:
-            raise UnsupportedCompressionMethodError(None, "inflate64 is not installed.")
+            raise UnsupportedCompressionMethodError(None, "deflate64 is disabled on pypy.")
         if self.flushed:
             return b""
         self.flushed = True
@@ -287,15 +287,15 @@ class Deflate64Compressor(ISevenZipCompressor):
 class Deflate64Decompressor(ISevenZipDecompressor):
     def __init__(self):
         self.flushed = False
-        if inflate64 is not None:
+        if hasattr(sys, "pypy_version_info"):
+            self._enabled = False
+        else:
             self._decompressor = inflate64.Inflater()
             self._enabled = True
-        else:
-            self._enabled = False
 
     def decompress(self, data: Union[bytes, bytearray, memoryview], max_length: int = -1) -> bytes:
         if not self._enabled:
-            raise UnsupportedCompressionMethodError(None, "inflate64 is not installed.")
+            raise UnsupportedCompressionMethodError(None, "deflate64 is disabled on pypy.")
         if len(data) == 0:
             if self.flushed:
                 return b""

--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -24,6 +24,7 @@
 import bz2
 import lzma
 import struct
+import sys
 import zlib
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -263,15 +264,15 @@ class DeflateDecompressor(ISevenZipDecompressor):
 class Deflate64Compressor(ISevenZipCompressor):
     def __init__(self):
         self.flushed = False
-        if inflate64 is not None:
+        if hasattr(sys, "pypy_version_info"):
+            self._enabled = False  # compression on pypy is disabled
+        else:
             self._compressor = inflate64.Deflater()
             self._enabled = True
-        else:
-            self._enabled = False
 
     def compress(self, data: Union[bytes, bytearray, memoryview], max_length: int = -1) -> bytes:
         if not self._enabled:
-            raise UnsupportedCompressionMethodError(None, "inflate64 is not installed.")
+            raise UnsupportedCompressionMethodError(None, "deflate64 compression is disabled on pypy.")
         return self._compressor.deflate(data)
 
     def flush(self) -> bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ depends =
 [testenv:py38]
 extras = test, test_compat
 
-[testenv:pypy3]
+[testenv:pypy38]
 extras = test, test_compat
 
 [testenv:mprof]

--- a/tests/test_extra_codecs.py
+++ b/tests/test_extra_codecs.py
@@ -262,7 +262,7 @@ def test_decompress_brotli(tmp_path):
 
 
 @pytest.mark.basic
-@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="No support for deflate64 compression on pypy")
+@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="No support for deflate64 on pypy")
 def test_compress_deflate64(tmp_path):
     # prepare source data
     with py7zr.SevenZipFile(testdata_path.joinpath("bzip2_2.7z").open(mode="rb")) as arc:
@@ -281,6 +281,7 @@ def test_compress_deflate64(tmp_path):
 
 
 @pytest.mark.basic
+@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="No support for deflate64 on pypy")
 def test_decompress_deflate64(tmp_path):
     with zipfile.ZipFile(srcdata) as srczip:
         srczip.extractall(path=tmp_path.joinpath("src"))

--- a/tests/test_extra_codecs.py
+++ b/tests/test_extra_codecs.py
@@ -15,7 +15,6 @@ from py7zr import UnsupportedCompressionMethodError
 from py7zr.properties import FILTER_DEFLATE64
 from tests import p7zip_test
 
-
 testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
 srcdata = testdata_path.joinpath("src.zip")
 os.umask(0o022)

--- a/tests/test_extra_codecs.py
+++ b/tests/test_extra_codecs.py
@@ -2,6 +2,7 @@ import hashlib
 import io
 import os
 import pathlib
+import sys
 import zipfile
 import zlib
 
@@ -14,10 +15,6 @@ from py7zr import UnsupportedCompressionMethodError
 from py7zr.properties import FILTER_DEFLATE64
 from tests import p7zip_test
 
-try:
-    import inflate64  # type: ignore
-except ImportError:
-    inflate64 = None
 
 testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
 srcdata = testdata_path.joinpath("src.zip")
@@ -266,7 +263,7 @@ def test_decompress_brotli(tmp_path):
 
 
 @pytest.mark.basic
-@pytest.mark.skipif(inflate64 is None, reason="inflate64 is not installed.")
+@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="No support for deflate64 compression on pypy")
 def test_compress_deflate64(tmp_path):
     # prepare source data
     with py7zr.SevenZipFile(testdata_path.joinpath("bzip2_2.7z").open(mode="rb")) as arc:
@@ -285,7 +282,6 @@ def test_compress_deflate64(tmp_path):
 
 
 @pytest.mark.basic
-@pytest.mark.skipif(inflate64 is None, reason="inflate64 is not installed.")
 def test_decompress_deflate64(tmp_path):
     with zipfile.ZipFile(srcdata) as srczip:
         srczip.extractall(path=tmp_path.joinpath("src"))

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 
@@ -98,7 +99,7 @@ def test_archivetest_deflate():
 
 
 @pytest.mark.files
-@pytest.mark.skipif(inflate64 is None, reason="inflate64 is not installed.")
+@pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="No support for deflate64 on pypy")
 def test_archivetest_deflate64():
     with py7zr.SevenZipFile(os.path.join(testdata_path, "deflate64.7z"), "r") as ar:
         assert ar.testzip() is None


### PR DESCRIPTION
- inflate64 library raises SIGABORT when compression on pypy
- Skip enhanced compression test on pypy

Signed-off-by: Hiroshi Miura <miurahr@linux.com>