### PR TITLE
typo fixed in user_guide.rst

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -158,7 +158,7 @@ Extraction
 ----------
 
 Here is a several example for extraction from your python program.
-You can write it with very clean syntax because py7zr supports context maanager.
+You can write it with very clean syntax because py7zr supports context manager.
 
 .. code-block:: python
 


### PR DESCRIPTION
Typo fixed. 
maanager => manager