### PR TITLE
Fix installation error in Cygwin

### DIFF
--- a/py7zr/properties.py
+++ b/py7zr/properties.py
@@ -25,7 +25,6 @@ import lzma
 import platform
 import sys
 
-import psutil  # type: ignore
 
 MAGIC_7Z = binascii.unhexlify("377abcaf271c")
 FINISH_7Z = binascii.unhexlify("377abcaf271d")
@@ -92,10 +91,11 @@ def get_memory_limit():
     :return: allowed chunk size in bytes.
     """
     default_limit = int(128e6)
-    if sys.platform.startswith("win"):
+    if sys.platform.startswith("win") or sys.platform.startswith('cygwin'):
         return default_limit
     else:
         import resource
+        import psutil  # type: ignore
 
         soft, _ = resource.getrlimit(resource.RLIMIT_AS)
         if soft == -1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
       'importlib_metadata;python_version<"3.8"',
       'brotli>=1.0.9;platform_python_implementation=="CPython"',
       'brotlicffi>=1.0.9.2;platform_python_implementation=="PyPy"',
-      "psutil",
+      'psutil;sys_platform!="cygwin"',
       "pyzstd>=0.14.4",
       "pyppmd>=0.18.1,<1.1.0",
       "pybcj>=0.6.0",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -8,7 +8,6 @@ import sys
 from contextlib import contextmanager
 
 import multivolumefile
-import psutil  # type: ignore
 import pytest
 
 import py7zr
@@ -176,10 +175,11 @@ def limit_memory(maxsize: int):
     :param maxsize: Maximum size of memory resource to limit
     :raises: MemoryError: When function reaches the limit.
     """
-    if sys.platform.startswith("win"):
+    if sys.platform.startswith("win") or sys.platform.startswith('cygwin'):
         yield
     else:
         import resource
+        import psutil  # type: ignore
 
         soft, hard = resource.getrlimit(resource.RLIMIT_AS)
         soft_new = psutil.Process(os.getpid()).memory_info().rss + maxsize


### PR DESCRIPTION
Install on Cygwin fails with below error
```
Requirement already satisfied: pybcj>=0.6.0 in /usr/local/lib/python3.9/site-packages (from py7zr) (1.0.1)
Collecting psutil
  Using cached psutil-5.9.4.tar.gz (485 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      platform cygwin is not supported
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```
as `psutil` doesn't support cygwin.

From source code of `py7zr` I see `psutil` actually doesn't have any effect on win platform, thus it won't be used on cygwin as well.

This PR conditionally removes `psutil` dependency on cygwin platform to fix the installation failure.

Tested by locally install and decompress files.

@miurahr would you review and merge please?