### PR TITLE
chore(ci): bump host macOS-12

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,17 +1,17 @@
 pool:
-  vmImage: 'macOS-10.15'
+  vmImage: 'macOS-latest'
 
 strategy:
   matrix:
     Python38:
-      python.version: '3.8'
-      TOXENV: py38
-    Python39:
       python.version: '3.9'
       TOXENV: py39
-    Python310:
+    Python39:
       python.version: '3.10'
       TOXENV: py310
+    Python310:
+      python.version: '3.11'
+      TOXENV: py311
 
 steps:
 - task: UsePythonVersion@0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ extras = test
 commands =
     python -m pytest -vv
 depends =
-    pypy{37,38,39},py{36,37,38,39,310}: clean, check
+    pypy{37,38,39},py{37,38,39,310,311}: clean, check
 
 [testenv:py38]
 extras = test, test_compat


### PR DESCRIPTION
- test with 3.9, 3.10, 3.11
- small fix of tox.ini to support py311