### PR TITLE
Fix an unhandled error "There are some data after the end of the payload data"

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -35,6 +35,7 @@ import queue
 import re
 import stat
 import sys
+import warnings
 from multiprocessing import Process
 from threading import Thread
 from typing import IO, Any, BinaryIO, Dict, List, Optional, Tuple, Type, Union
@@ -1446,6 +1447,13 @@ class Worker:
                 out_remaining -= len(tmp)
                 fq.write(tmp)
                 crc32 = calculate_crc32(tmp, crc32)
+            else:
+                # The message q is not passed here, so we use a simpler one for now
+                warnings.warn("There are some data after the end of the payload data!")
+                # out_remaining -= 1
+                # or make it simpler, just break.
+                break
+
             if out_remaining <= 0:
                 break
         if fp.tell() >= src_end:


### PR DESCRIPTION
#536
Now when the problem happens, the code will raise the warning and break the dead loop. The other option which is force 1 place forward is also provided inside the code. Choose which you want (I am not familiar with decompression logic, but break works fine in my case. It may lead to potential data loss, or maybe not, idk). The warning is handled via warnings.warn, because I want to remain most part of the code unchanged. Other wise you can try to use the report method perhaps, but the parameter self.q seems not available in this method now.