### PR TITLE
fix #540: replace deprecated functions on python 3.12

### DIFF
--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -9,7 +9,7 @@ import pathlib
 import shutil
 import stat
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -43,7 +43,7 @@ def test_compress_single_encoded_header(capsys, tmp_path):
     archive = py7zr.SevenZipFile(target, "r")
     assert archive.testzip() is None
     archive.close()
-    mtime = datetime.utcfromtimestamp(pathlib.Path(os.path.join(testdata_path, "test1.txt")).stat().st_mtime)
+    mtime = datetime.fromtimestamp(pathlib.Path(os.path.join(testdata_path, "test1.txt")).stat().st_mtime, timezone.utc)
     expected = (
         "total 1 files and directories in archive\n"
         "   Date      Time    Attr         Size   Compressed  Name\n"
@@ -171,7 +171,7 @@ def test_compress_file_0(capsys, tmp_path):
     archive = py7zr.SevenZipFile(target, "r")
     assert archive.header.main_streams.substreamsinfo.num_unpackstreams_folders[0] == 1
     assert archive.testzip() is None
-    mtime = datetime.utcfromtimestamp(pathlib.Path(os.path.join(testdata_path, "test1.txt")).stat().st_mtime)
+    mtime = datetime.fromtimestamp(pathlib.Path(os.path.join(testdata_path, "test1.txt")).stat().st_mtime, timezone.utc)
     expected = (
         "total 1 files and directories in archive\n"
         "   Date      Time    Attr         Size   Compressed  Name\n"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -425,7 +425,11 @@ def test_close_unlink(tmp_path):
 @pytest.mark.skipif(hasattr(sys, "pypy_version_info"), reason="Not working with pypy3")
 def test_asyncio_executor(tmp_path):
     shutil.copyfile(os.path.join(testdata_path, "test_1.7z"), str(tmp_path.joinpath("test_1.7z")))
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     task = asyncio.ensure_future(aio7zr(tmp_path.joinpath("test_1.7z"), path=tmp_path))
     loop.run_until_complete(task)
     loop.run_until_complete(asyncio.sleep(3))


### PR DESCRIPTION
Based on the [deprecated section](https://docs.python.org/3/whatsnew/3.12.html#deprecated) of Python 3.12 documentation about asyncio and datetime modules.

I went for `datetime.datetime.fromtimestamp(..., datetime.timezone.utc)` instead of `datetime.datetime.fromtimestamp(..., datetime.UTC)` as the [latter](https://docs.python.org/3/library/datetime.html#datetime.UTC) is only an alias for the first since 3.11.

[asyncio.get_running_loop](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_running_loop) is only available since 3.7 but if I'm not mistaken this is the minimum required version for this project.