### PR TITLE
Treat zero byte stream as a file.

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -892,7 +892,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         f["data"] = bio
         f["filename"] = pathlib.Path(arcname).as_posix()
         f["uncompressed"] = size
-        f["emptystream"] = size == None
+        f["emptystream"] = False
         f["attributes"] = getattr(stat, "FILE_ATTRIBUTE_ARCHIVE")
         f["creationtime"] = ArchiveTimestamp.from_now()
         f["lastwritetime"] = ArchiveTimestamp.from_now()

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -892,7 +892,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         f["data"] = bio
         f["filename"] = pathlib.Path(arcname).as_posix()
         f["uncompressed"] = size
-        f["emptystream"] = size == 0
+        f["emptystream"] = size == None
         f["attributes"] = getattr(stat, "FILE_ATTRIBUTE_ARCHIVE")
         f["creationtime"] = ArchiveTimestamp.from_now()
         f["lastwritetime"] = ArchiveTimestamp.from_now()
@@ -1064,7 +1064,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
             size = last - current
         else:
             raise ValueError("Wrong argument passed for argument bio.")
-        if size > 0:
+        if size >= 0:
             folder = self.header.initialize()
             file_info = self._make_file_info_from_name(bio, size, arcname)
             self.header.files_info.files.append(file_info)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1167,8 +1167,10 @@ def test_compress_win32_absolute_arcname(tmp_path):
 
 @pytest.mark.files
 def test_empty_stream(tmp_path):
-    try:
-        with py7zr.SevenZipFile(file=tmp_path / "test.7z", mode="w") as archive:
-            archive.writestr(data="", arcname="empty.txt")
-    except AttributeError:
-        pytest.fail("Exception raised")
+    archive = py7zr.SevenZipFile(file=tmp_path / "test.7z", mode="w")
+    archive.writestr(data="", arcname="empty.txt")
+    assert len(archive.files.files_list) == 1
+    assert archive.header.files_info.files[0]["emptystream"] is True
+    archive.close()
+    p7zip_test(tmp_path / "test.7z")
+

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1164,11 +1164,4 @@ def test_compress_win32_absolute_arcname(tmp_path):
     p7zip_test(tmp_path / "target.7z")
     libarchive_extract(tmp_path / "target.7z", tmp_path.joinpath("tgt2"))
 
-@pytest.mark.files
-def test_empty_stream(tmp_path):
-    target = tmp_path.joinpath("target.7z")
-    try:
-        with py7zr.SevenZipFile(file=target,mode="w") as archive:
-        archive.writestr(data="",arcname="empty.txt")
-    except:
-        pytest.fail("Exception raised")
+

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1166,8 +1166,9 @@ def test_compress_win32_absolute_arcname(tmp_path):
 
 @pytest.mark.files
 def test_empty_stream(tmp_path):
-  try:
-    with py7zr.SevenZipFile(file="test.7z",mode="w") as archive:
-      archive.writestr(data="",arcname="empty.txt")
-  except:
-    pytest.fail("Exception raised")
+    target = tmp_path.joinpath("target.7z")
+    try:
+        with py7zr.SevenZipFile(file=target,mode="w") as archive:
+        archive.writestr(data="",arcname="empty.txt")
+    except:
+        pytest.fail("Exception raised")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1170,5 +1170,5 @@ def test_empty_stream(tmp_path):
     try:
         with py7zr.SevenZipFile(file="test.7z", mode="w") as archive:
         archive.writestr(data="", arcname="empty.txt")
-    except:
+    except AttributeError:
         pytest.fail("Exception raised")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1163,3 +1163,11 @@ def test_compress_win32_absolute_arcname(tmp_path):
     #
     p7zip_test(tmp_path / "target.7z")
     libarchive_extract(tmp_path / "target.7z", tmp_path.joinpath("tgt2"))
+
+@pytest.mark.files
+def test_empty_stream(tmp_path):
+  try:
+    with py7zr.SevenZipFile(file="test.7z",mode="w") as archive:
+      archive.writestr(data="",arcname="empty.txt")
+  except:
+    pytest.fail("Exception raised")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1170,7 +1170,7 @@ def test_empty_stream(tmp_path):
     archive = py7zr.SevenZipFile(file=tmp_path / "test.7z", mode="w")
     archive.writestr(data="", arcname="empty.txt")
     assert len(archive.files.files_list) == 1
-    assert archive.header.files_info.files[0]["emptystream"] is True
+    # assert archive.header.files_info.files[0]["emptystream"] is True
     archive.close()
     p7zip_test(tmp_path / "test.7z")
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1170,7 +1170,7 @@ def test_empty_stream(tmp_path):
     archive = py7zr.SevenZipFile(file=tmp_path / "test.7z", mode="w")
     archive.writestr(data="", arcname="empty.txt")
     assert len(archive.files.files_list) == 1
-    assert archive.header.files_info.files[0]['uncompressed'] == 0
+    assert archive.header.files_info.files[0]["uncompressed"] == 0
     archive.close()
     p7zip_test(tmp_path / "test.7z")
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1170,7 +1170,7 @@ def test_empty_stream(tmp_path):
     archive = py7zr.SevenZipFile(file=tmp_path / "test.7z", mode="w")
     archive.writestr(data="", arcname="empty.txt")
     assert len(archive.files.files_list) == 1
-    # assert archive.header.files_info.files[0]["emptystream"] is True
+    assert archive.header.files_info.files[0]['uncompressed'] == 0
     archive.close()
     p7zip_test(tmp_path / "test.7z")
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1167,4 +1167,8 @@ def test_compress_win32_absolute_arcname(tmp_path):
 
 @pytest.mark.files
 def test_empty_stream(tmp_path):
-    target = tmp_path.joinpath("target.7z")
+  try:
+    with py7zr.SevenZipFile(file="test.7z",mode="w") as archive:
+      archive.writestr(data="",arcname="empty.txt")
+  except:
+    pytest.fail("Exception raised")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1169,6 +1169,6 @@ def test_compress_win32_absolute_arcname(tmp_path):
 def test_empty_stream(tmp_path):
     try:
         with py7zr.SevenZipFile(file="test.7z", mode="w") as archive:
-        archive.writestr(data="", arcname="empty.txt")
+            archive.writestr(data="", arcname="empty.txt")
     except AttributeError:
         pytest.fail("Exception raised")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1165,3 +1165,11 @@ def test_compress_win32_absolute_arcname(tmp_path):
     libarchive_extract(tmp_path / "target.7z", tmp_path.joinpath("tgt2"))
 
 
+@pytest.mark.files
+def test_empty_stream(tmp_path):
+    target = tmp_path.joinpath("target.7z")
+    try:
+        with py7zr.SevenZipFile(file=target,mode="w") as archive:
+        archive.writestr(data="",arcname="empty.txt")
+    except:
+        pytest.fail("Exception raised")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1168,8 +1168,3 @@ def test_compress_win32_absolute_arcname(tmp_path):
 @pytest.mark.files
 def test_empty_stream(tmp_path):
     target = tmp_path.joinpath("target.7z")
-    try:
-        with py7zr.SevenZipFile(file=target,mode="w") as archive:
-        archive.writestr(data="",arcname="empty.txt")
-    except:
-        pytest.fail("Exception raised")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1173,4 +1173,3 @@ def test_empty_stream(tmp_path):
     assert archive.header.files_info.files[0]["uncompressed"] == 0
     archive.close()
     p7zip_test(tmp_path / "test.7z")
-

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1167,8 +1167,8 @@ def test_compress_win32_absolute_arcname(tmp_path):
 
 @pytest.mark.files
 def test_empty_stream(tmp_path):
-  try:
-    with py7zr.SevenZipFile(file="test.7z",mode="w") as archive:
-      archive.writestr(data="",arcname="empty.txt")
-  except:
-    pytest.fail("Exception raised")
+    try:
+        with py7zr.SevenZipFile(file="test.7z",mode="w") as archive:
+        archive.writestr(data="",arcname="empty.txt")
+    except:
+        pytest.fail("Exception raised")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1168,7 +1168,7 @@ def test_compress_win32_absolute_arcname(tmp_path):
 @pytest.mark.files
 def test_empty_stream(tmp_path):
     try:
-        with py7zr.SevenZipFile(file="test.7z", mode="w") as archive:
+        with py7zr.SevenZipFile(file=tmp_path / "test.7z", mode="w") as archive:
             archive.writestr(data="", arcname="empty.txt")
     except AttributeError:
         pytest.fail("Exception raised")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1168,7 +1168,7 @@ def test_compress_win32_absolute_arcname(tmp_path):
 @pytest.mark.files
 def test_empty_stream(tmp_path):
     try:
-        with py7zr.SevenZipFile(file="test.7z",mode="w") as archive:
-        archive.writestr(data="",arcname="empty.txt")
+        with py7zr.SevenZipFile(file="test.7z", mode="w") as archive:
+        archive.writestr(data="", arcname="empty.txt")
     except:
         pytest.fail("Exception raised")


### PR DESCRIPTION
Ref to issue [#549](https://github.com/miurahr/py7zr/issues/549) and issue [#398](https://github.com/miurahr/py7zr/issues/398). This pull request will fix those issues by treating zero byte stream as a file.