### PR TITLE
Remove obsolete words in comments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Configuration for pytest to automatically collect types.
+# Configuration for pytest.
 # Thanks to Guilherme Salgado.
 
 import cpuinfo


### PR DESCRIPTION
As of https://github.com/miurahr/py7zr/pull/552 , pyannotate line is now removed.
This patch removes obsolete words in comments.