### PR TITLE
add report_update() for logging large files extraction

### DIFF
--- a/py7zr/callbacks.py
+++ b/py7zr/callbacks.py
@@ -36,6 +36,11 @@ class Callback(ABC):
         pass  # noqa
 
     @abstractmethod
+    def report_update(self, decompressed_bytes):
+        """report an event for decompressed part of file."""
+        pass  # noqa
+
+    @abstractmethod
     def report_end(self, processing_file_path, wrote_bytes):
         """report an end event of specified archive file and its output bytes."""
         pass  # noqa

--- a/py7zr/callbacks.py
+++ b/py7zr/callbacks.py
@@ -37,7 +37,7 @@ class Callback(ABC):
 
     @abstractmethod
     def report_update(self, decompressed_bytes):
-        """report an event for decompressed part of file."""
+        """report an event when large file is being extracted more than 1 second or when extraction is finished."""
         pass  # noqa
 
     @abstractmethod

--- a/py7zr/callbacks.py
+++ b/py7zr/callbacks.py
@@ -37,7 +37,8 @@ class Callback(ABC):
 
     @abstractmethod
     def report_update(self, decompressed_bytes):
-        """report an event when large file is being extracted more than 1 second or when extraction is finished."""
+        """report an event when large file is being extracted more than 1 second or when extraction is finished.
+        receives a number of decompressed bytes since the last update."""
         pass  # noqa
 
     @abstractmethod

--- a/py7zr/cli.py
+++ b/py7zr/cli.py
@@ -57,6 +57,9 @@ class CliExtractCallback(ExtractCallback):
         self.ofd.write("- {}".format(processing_file_path))
         self.pwidth += len(processing_file_path) + 2
 
+    def report_update(self, decompressed_bytes):
+        pass
+
     def report_end(self, processing_file_path, wrote_bytes):
         self.total_bytes += int(wrote_bytes)
         plest = self.columns - self.pwidth

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -137,6 +137,9 @@ def test_extract_callback(tmp_path):
         def report_start(self, processing_file_path, processing_bytes):
             self.ofd.write('start "{}" (compressed in {} bytes)\n'.format(processing_file_path, processing_bytes))
 
+        def report_update(self, decompressed_bytes):
+            self.ofd.write('decompressed part of {} bytes\n'.format(decompressed_bytes))
+
         def report_end(self, processing_file_path, wrote_bytes):
             self.ofd.write('end "{}" extracted to {} bytes\n'.format(processing_file_path, wrote_bytes))
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -138,7 +138,7 @@ def test_extract_callback(tmp_path):
             self.ofd.write('start "{}" (compressed in {} bytes)\n'.format(processing_file_path, processing_bytes))
 
         def report_update(self, decompressed_bytes):
-            self.ofd.write('decompressed part of {} bytes\n'.format(decompressed_bytes))
+            self.ofd.write("decompressed part of {} bytes\n".format(decompressed_bytes))
 
         def report_end(self, processing_file_path, wrote_bytes):
             self.ofd.write('end "{}" extracted to {} bytes\n'.format(processing_file_path, wrote_bytes))


### PR DESCRIPTION
## Pull request type
- Feature enhancement

## Which ticket is resolved?
- issue #526 

## What does this PR change?
Event "u" (update) is called when file is being extracted more that 1 second or when already extracted.
Function report_update() receives decompressed_bytes count for decompressed part.
Should be useful for progress bar implementation.

## Example
```
import py7zr
from tqdm import tqdm


class ExtractProgressBar(py7zr.callbacks.ExtractCallback, tqdm):
    def __init__(self, *args, total_bytes, **kwargs):
        super().__init__(self, *args, total=total_bytes, **kwargs)

    def report_start_preparation(self):
        pass

    def report_start(self, processing_file_path, processing_bytes):
        pass

    def report_end(self, processing_file_path, wrote_bytes):
        pass

    def report_update(self, decompressed_bytes):
        self.update(int(decompressed_bytes))

    def report_postprocess(self):
        pass

    def report_warning(self, message):
        pass


def extract_7z(src_path, dst_path):
    with py7zr.SevenZipFile(src_path, 'r') as archive:
        archive_info = archive.archiveinfo()
        with ExtractProgressBar(
            unit='B',
            unit_scale=True,
            miniters=1,
            total_bytes=archive_info.uncompressed,
            desc=f"Extracting",
            ascii=True,
        ) as progress:
            archive.extractall(path=dst_path, callback=progress)
```