### PR TITLE
feat: check `targets` argument type for read and extract method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -180,14 +180,19 @@ SevenZipFile Object
 .. py:method:: SevenZipFile.extract(path=None, targets=None)
 
    Extract specified pathspec archived files to current working directory.
-   'path' specifies a differenct directory to extract to.
+   'path' specifies a different directory to extract to.
 
-   'targets' is a list of archived files to be extracted. py7zr looks for files
-   and directories as same as specified in 'targets'.
+   'targets' is a COLLECTION of archived file names to be extracted.
+   py7zr looks for files and directories as same as specified in element
+   of 'targets'.
 
-   Once extract() called, the SevenZipFIle object become exhausted and EOF state.
-   If you want to call read(), readall(), extract(), extractall() again,
-   you should call reset() before it.
+   When the method get a ``str`` object or another object other than collection
+   such as LIST or SET, it will raise :exc:`TypeError`.
+
+   Once extract() called, the ``SevenZipFile`` object become exhausted,
+   and an EOF state.
+   If you want to call :meth:`read`, :meth:`readall`, :meth:`extract`, :meth:`extractall`
+   again, you should call :meth:`reset` before it.
 
    **CAUTION** when specifying files and not specifying parent directory,
    py7zr will fails with no such directory. When you want to extract file
@@ -226,8 +231,14 @@ SevenZipFile Object
 .. py:method:: SevenZipFile.read(targets=None)
 
    Extract specified list of target archived files to dictionary object.
-   'targets' is a list of archived files to be extracted. py7zr looks for files
-   and directories as same as specified in 'targets'.
+
+   'targets' is a COLLECTION of archived file names to be extracted.
+   py7zr looks for files and directories as same as specified in element
+   of 'targets'.
+
+   When the method get a ``str`` object or another object other than collection
+   such as LIST or SET, it will raise :exc:`TypeError`.
+
    When targets is None, it behave as same as readall().
    Once read() called, the SevenZipFIle object become exhausted and EOF state.
    If you want to call read(), readall(), extract(), extractall() again,

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -918,16 +918,16 @@ class SevenZipFile(contextlib.AbstractContextManager):
             raise AbsolutePathError(arcname)
         return path
 
-    def _is_collection_of_str(self, t):
+    def _is_none_or_collection(self, t):
         if t is None:
             return True
         if isinstance(t, str):
             return False
-        try:
-            len(t)
-            return all(isinstance(x, str) for x in t)
-        except Exception:
+        if isinstance(t, tuple):
             return False
+        if isinstance(t, list) or isinstance(t, set):
+            return True
+        return False
 
     # --------------------------------------------------------------------------
     # The public methods which SevenZipFile provides:
@@ -992,13 +992,13 @@ class SevenZipFile(contextlib.AbstractContextManager):
         self._extract(path=path, return_dict=False, callback=callback)
 
     def read(self, targets: Optional[Collection[str]] = None) -> Optional[Dict[str, IO[Any]]]:
-        if not self._is_collection_of_str(targets):
+        if not self._is_none_or_collection(targets):
             raise TypeError("Wrong argument type given.")
         self._dict = {}
         return self._extract(path=None, targets=targets, return_dict=True)
 
     def extract(self, path: Optional[Any] = None, targets: Optional[Collection[str]] = None) -> None:
-        if not self._is_collection_of_str(targets):
+        if not self._is_none_or_collection(targets):
             raise TypeError("Wrong argument type given.")
         self._extract(path, targets, return_dict=False)
 

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -918,6 +918,17 @@ class SevenZipFile(contextlib.AbstractContextManager):
             raise AbsolutePathError(arcname)
         return path
 
+    def _is_collection_of_str(self, t):
+        if t is None:
+            return True
+        if isinstance(t, str):
+            return False
+        try:
+            len(t)
+            return all(isinstance(x, str) for x in t)
+        except Exception:
+            return False
+
     # --------------------------------------------------------------------------
     # The public methods which SevenZipFile provides:
     def getnames(self) -> List[str]:
@@ -981,10 +992,14 @@ class SevenZipFile(contextlib.AbstractContextManager):
         self._extract(path=path, return_dict=False, callback=callback)
 
     def read(self, targets: Optional[Collection[str]] = None) -> Optional[Dict[str, IO[Any]]]:
+        if not self._is_collection_of_str(targets):
+            raise TypeError("Wrong argument type given.")
         self._dict = {}
         return self._extract(path=None, targets=targets, return_dict=True)
 
     def extract(self, path: Optional[Any] = None, targets: Optional[Collection[str]] = None) -> None:
+        if not self._is_collection_of_str(targets):
+            raise TypeError("Wrong argument type given.")
         self._extract(path, targets, return_dict=False)
 
     def reporter(self, callback: ExtractCallback):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,9 @@
+import base64
 import os
 import pathlib
 import re
 import shutil
+from io import BytesIO
 
 import pytest
 
@@ -280,3 +282,20 @@ def test_multiple_uses():
     with py7zr.SevenZipFile(os.path.join(testdata_path, "test_multiple.7z"), "w") as archive:
         archive.writestr("1", "1.txt")
         archive.test()
+
+
+@pytest.mark.basic
+def test_decrypt_memory_read():
+    data = base64.b64decode(
+        "N3q8ryccAAT9xtacpQAAAAAAAAAiAAAAAAAAAEerl+XBRlkrcJwwoqgijCyuEh0S"
+        "qLfjamv2F2vNJGFGyHDfpAAAgTMHrg/QDrA8nzkQnJ+m1TPasi6xAvSHzZaZrISL"
+        "D+EsvFULZ44Kf7Ewy47PApbKruXCaOSUsjzeqpG8VBcx66h2cV/lnGDfUjtVsyGB"
+        "HmmmTaSI/atXtuwiN5mGrqyFZTC/V2VEohWua1Yk1K+jXy+32hBwnK2clyr3rN5L"
+        "Abv5g2wXBiABCYCFAAcLAQABIwMBAQVdABAAAAyAlgoBouB4BAAA"
+    )
+    arc = py7zr.SevenZipFile(BytesIO(data), password="boom")
+    result = arc.read(["bar.txt"])
+    assert "bar.txt" in result
+    bina = result.get("bar.txt")
+    assert isinstance(bina, BytesIO)
+    assert bina.read() == b"refinery"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -285,7 +285,7 @@ def test_multiple_uses():
 
 
 @pytest.mark.basic
-def test_decrypt_memory_read():
+def test_read_collection_argument():
     data = base64.b64decode(
         "N3q8ryccAAT9xtacpQAAAAAAAAAiAAAAAAAAAEerl+XBRlkrcJwwoqgijCyuEh0S"
         "qLfjamv2F2vNJGFGyHDfpAAAgTMHrg/QDrA8nzkQnJ+m1TPasi6xAvSHzZaZrISL"
@@ -294,8 +294,20 @@ def test_decrypt_memory_read():
         "Abv5g2wXBiABCYCFAAcLAQABIwMBAQVdABAAAAyAlgoBouB4BAAA"
     )
     with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-        result = arc.read(["bar.txt"])
+        result = arc.read(["bar.txt"])  # list -> ok
         assert "bar.txt" in result
         bina = result.get("bar.txt")
         assert isinstance(bina, BytesIO)
         assert bina.read() == b"refinery"
+    with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
+        result = arc.read({"bar.txt"})  # set -> ok
+        assert result.get("bar.txt").read() == b"refinery"
+    with pytest.raises(TypeError):
+        with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
+            arc.read(("bar.txt"))  # tuple -> bad
+    with pytest.raises(TypeError):
+        with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
+            arc.read("bar.txt")  # str -> bad
+    with pytest.raises(TypeError):
+        with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
+            arc.extract(targets="bar.txt")  # str -> bad

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -293,9 +293,9 @@ def test_decrypt_memory_read():
         "HmmmTaSI/atXtuwiN5mGrqyFZTC/V2VEohWua1Yk1K+jXy+32hBwnK2clyr3rN5L"
         "Abv5g2wXBiABCYCFAAcLAQABIwMBAQVdABAAAAyAlgoBouB4BAAA"
     )
-    arc = py7zr.SevenZipFile(BytesIO(data), password="boom")
-    result = arc.read(["bar.txt"])
-    assert "bar.txt" in result
-    bina = result.get("bar.txt")
-    assert isinstance(bina, BytesIO)
-    assert bina.read() == b"refinery"
+    with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
+        result = arc.read(["bar.txt"])
+        assert "bar.txt" in result
+        bina = result.get("bar.txt")
+        assert isinstance(bina, BytesIO)
+        assert bina.read() == b"refinery"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -304,7 +304,7 @@ def test_read_collection_argument():
         assert result.get("bar.txt").read() == b"refinery"
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-            arc.read(("bar.txt"))  # tuple -> bad
+            arc.read(("bar.txt",))  # tuple -> bad
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
             arc.read("bar.txt")  # str -> bad


### PR DESCRIPTION
Add a test case to reproduce issue report #576 
#576 report `arc.read("bar.txt")` returns nothing. It is wrong argument type that should be collection but str.

test on py7zr version v0.20.8 to confirm it is passed,  then merge master and check it become failure but not.

- test on v0.20.8 -- https://github.com/miurahr/py7zr/actions/runs/8133865562?pr=577
- test on master -- https://github.com/miurahr/py7zr/actions/runs/8133905949?pr=577

We should check type of argument before continue to help user to use a method properly. 

## Pull request type
 
select from below

- Feature enhancement
- Documentation

## Which ticket is resolved?

- issue #576

## What does this PR change?
- test case that decrypt and read specific target file
- Test with list and set of "bar.txt" entry for  targets argument.
- Test with str in targets argument and it should raise TypeError

## Other information
