### PR TITLE
feat: make unpack_7zarchive raise ReadError for invalid files

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -37,6 +37,7 @@ import stat
 import sys
 import time
 from multiprocessing import Process
+from shutil import ReadError
 from threading import Thread
 from typing import IO, Any, BinaryIO, Collection, Dict, List, Optional, Tuple, Type, Union
 
@@ -1210,6 +1211,8 @@ def unpack_7zarchive(archive, path, extra=None):
     """
     Function for registering with shutil.register_unpack_format().
     """
+    if not is_7zfile(archive):
+        raise ReadError(f"{archive} is not a 7zip file.")
     with SevenZipFile(archive) as arc:
         arc.extractall(path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,17 @@
 # Configuration for pytest.
 # Thanks to Guilherme Salgado.
 
+import shutil
+
 import cpuinfo
 import pytest
+
+from py7zr import unpack_7zarchive
+
+
+@pytest.fixture(scope="session")
+def register_shutil_unpack_format():
+    shutil.register_unpack_format("7zip", [".7z"], unpack_7zarchive)
 
 
 def pytest_benchmark_update_json(config, benchmarks, output_json):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -7,12 +7,12 @@ import pathlib
 import shutil
 import subprocess
 import sys
+import tempfile
 from datetime import datetime
 
 import pytest
 
 import py7zr
-from py7zr import unpack_7zarchive
 from py7zr.exceptions import CrcError, UnsupportedCompressionMethodError
 from py7zr.helpers import UTC
 
@@ -306,8 +306,7 @@ def test_zerosize_mem():
 
 
 @pytest.mark.api
-def test_register_unpack_archive(tmp_path):
-    shutil.register_unpack_format("7zip", [".7z"], unpack_7zarchive)
+def test_register_unpack_archive(register_shutil_unpack_format, tmp_path):
     shutil.unpack_archive(str(testdata_path.joinpath("test_1.7z")), str(tmp_path))
     target = tmp_path.joinpath("setup.cfg")
     expected_mode = 33188
@@ -324,6 +323,12 @@ def test_register_unpack_archive(tmp_path):
     m = hashlib.sha256()
     m.update(tmp_path.joinpath("scripts/py7zr").open("rb").read())
     assert m.digest() == binascii.unhexlify("b0385e71d6a07eb692f5fb9798e9d33aaf87be7dfff936fd2473eab2a593d4fd")
+
+
+@pytest.mark.api
+def test_register_unpack_archive_error(register_shutil_unpack_format, tmp_path):
+    with tempfile.NamedTemporaryFile(suffix=".7z") as f, pytest.raises(shutil.ReadError):
+        shutil.unpack_archive(f.name, str(tmp_path))
 
 
 @pytest.mark.files


### PR DESCRIPTION
## Pull request type

- Feature enhancement

## Which ticket is resolved?

None open yet, the change seems pretty small.

## What does this PR change?

Follow `shutil.register_unpack_format()` convention of raising a `ReadError` when the library cannot handle a file.

## Other information

Docstring documenting the interface:
https://github.com/python/cpython/blob/22b25d1ebaab7b8c4833a8c120c8b4699a830f40/Lib/shutil.py#L1264-L1265

Example uses:
https://github.com/python/cpython/blob/22b25d1ebaab7b8c4833a8c120c8b4699a830f40/Lib/shutil.py#L1292-L1293
https://github.com/python/cpython/blob/22b25d1ebaab7b8c4833a8c120c8b4699a830f40/Lib/shutil.py#L1324-L1325
