### PR TITLE
feat: ensure unpack_7zarchive closes the archive

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -1202,9 +1202,8 @@ def unpack_7zarchive(archive, path, extra=None):
     """
     Function for registering with shutil.register_unpack_format().
     """
-    arc = SevenZipFile(archive)
-    arc.extractall(path)
-    arc.close()
+    with SevenZipFile(archive) as arc:
+        arc.extractall(path)
 
 
 def pack_7zarchive(base_name, base_dir, owner=None, group=None, dry_run=None, logger=None):


### PR DESCRIPTION
## Pull request type

- Feature enhancement

## Which ticket is resolved?

None, it’s a pretty small implementation detail.

## What does this PR change?

- Always call `SevenZipFile.close()` even when there was an exception during `extractall()` in `unpack_7zarchive()`.
