### PR TITLE
docs: Use same format for `unpack_archive` example as for `make_archive`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -49,7 +49,7 @@ The module defines the following items:
 .. code-block:: python
 
     shutil.register_unpack_format('7zip', ['.7z'], unpack_7zarchive)
-    shutil.unpack_archive(filename, [, extract_dir])
+    shutil.unpack_archive(filename, extract_dir)
 
 
 .. function:: pack_7zarchive(archive, path, extra=None)


### PR DESCRIPTION
## Pull request type
 
- Documentation

## What does this PR change?
- This PR aims to make the documentation very slightly more consistent by changing one example in the documentation. The current example matches the format in [the shutil doc](https://docs.python.org/3/library/shutil.html#shutil.unpack_archive), whereas the [`pack_7zarchive`](https://py7zr.readthedocs.io/en/latest/api.html#py7zr.pack_7zarchive) example does not. 