### PR TITLE
Prevent crash - Change the threshold for a full 9-byte number

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -154,7 +154,7 @@ def write_uint64(file: Union[BinaryIO, WriteWithCrc], value: int):
     if value < 0x80:
         file.write(pack("B", value))
         return
-    if value > 0x01FFFFFFFFFFFFFF:
+    if value > 0xFFFFFFFFFFFFFF:
         file.write(b"\xff")
         file.write(value.to_bytes(8, "little"))
         return


### PR DESCRIPTION
Attempting to encode numbers between 0xFFFFFFFFFFFFFF and 0x01FFFFFFFFFFFFFF would result in an error.  Because the byte length is 8, the value of (8 - byte_length - 1) was negative, resulting in an attempt to shift by a negative number of bits which caused an error.

## Pull request type
 
- Bug fix

## Which ticket is resolved?

None that I know of

## What does this PR change?
Changes the threshold for when to use a nine-byte representation of a number.

## Other information
