### PR TITLE
fix: handle trailing slash

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -1031,6 +1031,10 @@ class SevenZipFile(contextlib.AbstractContextManager):
     def read(self, targets: Optional[Collection[str]] = None) -> Optional[Dict[str, IO[Any]]]:
         if not self._is_none_or_collection(targets):
             raise TypeError("Wrong argument type given.")
+        # For interoperability with ZipFile, we strip any trailing slashes
+        # This also matches the behavior of TarFile
+        if targets is not None:
+            targets = [remove_trailing_slash(target) for target in targets]
         self._dict = {}
         return self._extract(path=None, targets=targets, return_dict=True)
 
@@ -1039,6 +1043,10 @@ class SevenZipFile(contextlib.AbstractContextManager):
     ) -> None:
         if not self._is_none_or_collection(targets):
             raise TypeError("Wrong argument type given.")
+        # For interoperability with ZipFile, we strip any trailing slashes
+        # This also matches the behavior of TarFile
+        if targets is not None:
+            targets = [remove_trailing_slash(target) for target in targets]
         self._extract(path, targets, return_dict=False, recursive=recursive)
 
     def reporter(self, callback: ExtractCallback):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -205,11 +205,45 @@ def test_py7zr_extract_specified_file(tmp_path):
 
 
 @pytest.mark.api
+def test_py7zr_extract_specified_file_with_trailing_slash(tmp_path):
+    archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "test_1.7z"), "rb"))
+    expected = [
+        {
+            "filename": "scripts/py7zr",
+            "mode": 33261,
+            "mtime": 1552522208,
+            "digest": "b0385e71d6a07eb692f5fb9798e9d33aaf87be7dfff936fd2473eab2a593d4fd",
+        }
+    ]
+    archive.extract(path=tmp_path, targets=["scripts/", "scripts/py7zr/"])
+    archive.close()
+    assert tmp_path.joinpath("scripts").is_dir()
+    assert tmp_path.joinpath("scripts/py7zr").exists()
+    assert not tmp_path.joinpath("setup.cfg").exists()
+    assert not tmp_path.joinpath("setup.py").exists()
+    check_output(expected, tmp_path)
+
+
+@pytest.mark.api
 def test_py7zr_extract_and_getnames(tmp_path):
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "test_1.7z"), "rb"))
     allfiles = archive.getnames()
     filter_pattern = re.compile(r"scripts.*")
     targets = [f for f in allfiles if filter_pattern.match(f)]
+    archive.extract(path=tmp_path, targets=targets)
+    archive.close()
+    assert tmp_path.joinpath("scripts").is_dir()
+    assert tmp_path.joinpath("scripts/py7zr").exists()
+    assert not tmp_path.joinpath("setup.cfg").exists()
+    assert not tmp_path.joinpath("setup.py").exists()
+
+
+@pytest.mark.api
+def test_py7zr_extract_with_trailing_slash_and_getnames(tmp_path):
+    archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "test_1.7z"), "rb"))
+    allfiles = archive.getnames()
+    filter_pattern = re.compile(r"scripts.*")
+    targets = [f"{f}/" for f in allfiles if filter_pattern.match(f)]
     archive.extract(path=tmp_path, targets=targets)
     archive.close()
     assert tmp_path.joinpath("scripts").is_dir()
@@ -238,6 +272,17 @@ def test_py7zr_read_and_reset(tmp_path):
     iterations = archive.getnames()
     for target in iterations:
         _dict = archive.read(targets=[target])
+        assert len(_dict) == 1
+        archive.reset()
+    archive.close()
+
+
+@pytest.mark.api
+def test_py7zr_read_with_trailing_slash_and_reset(tmp_path):
+    archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "read_reset.7z"), "rb"))
+    iterations = archive.getnames()
+    for target in iterations:
+        _dict = archive.read(targets=[f"{target}/"])
         assert len(_dict) == 1
         archive.reset()
     archive.close()


### PR DESCRIPTION
## Pull request type
- Feature enhancement

## What does this PR change?
Following in the footsteps of https://github.com/miurahr/py7zr/pull/609#issuecomment-2276282122, this PR makes it so `archive.read("some/file/") == archive.read("some/file") is True`. This matches the behavior of [TarFile](https://github.com/python/cpython/blob/c536f59c62eca95f0f4ef3fd688f5c387dd40ae6/Lib/tarfile.py#L1983) and allows for interoperability with ZipFiles