### PR TITLE
docs: group getnames and namelist together

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -161,6 +161,7 @@ SevenZipFile Object
 
 
 .. py:method:: SevenZipFile.getnames()
+               SevenZipFile.namelist()
 
    Return a list of archive files by name.
 
@@ -286,9 +287,7 @@ SevenZipFile Object
 
     Return a ArchiveInfo object.
 
-.. py:method:: SevenZipFile.namelist()
 
-    Return a list of archive members by name.
 
 .. py:method:: SevenZipFile.test()
 


### PR DESCRIPTION
## Pull request type
- Documentation

## What does this PR change?
Since `getnames()` and `namelist()` are identical, this PR groups them up in documentation.
This is how it looks now:
![image](https://github.com/user-attachments/assets/8fd7e867-38e4-485c-bc37-4a966fb7ff8a)

