### PR TITLE
refactor: drop read/readall method, and add feature to stream data into user object

### DIFF
--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -137,7 +137,7 @@ jobs:
           run: |
             git config --global --add safe.directory ${GITHUB_WORKSPACE}
             python3 -c "import platform;print('Machine type:', platform.machine())"
-            python3 -m tox -e py311
+            python3 -m tox -e py310
           env: |
             PYTEST_ADDOPTS: "--cov-config=pyproject.toml --cov --cov-append --benchmark-skip"
 

--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -137,7 +137,7 @@ jobs:
           run: |
             git config --global --add safe.directory ${GITHUB_WORKSPACE}
             python3 -c "import platform;print('Machine type:', platform.machine())"
-            python3 -m tox -e py310
+            python3 -m tox -e py311
           env: |
             PYTEST_ADDOPTS: "--cov-config=pyproject.toml --cov --cov-append --benchmark-skip"
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,0 +1,76 @@
+.. _advanced_usage:
+
+**************
+Advanced usage
+**************
+
+Stream 7z content
+-----------------
+
+The py7zr provide a way to stream archive content with ``read`` and ``readall`` methods.
+The ``read`` and ``readall`` methods accept an object which implement ``py7zr.io.WriterFactory`` interface.
+Your custom class which implements ``WriterFactory`` interface should have ``create`` method.
+The ``create`` method should return your custom class object which implements ``Py7zIO`` interface.
+The ``Py7zIO`` interface is mostly as same as Python Standard ``BinaryIO`` but it also have ``size`` method.
+
+When the py7zr extract the archive contents, it calls the factory object with filename and ask creating the io object.
+The py7zr write the io object with ``write`` method, which is as similar as an object returned by the standard ``open`` method.
+
+You can process ``write`` in your custom class. The method is called on-the-fly when the py7zr move to extract the target
+archive file.
+
+Note: Because the py7zr run in multi-threaded, your custom class should be thread-safe.
+
+The py7zr provide the way to stream content without buffering all the archive content in a memory, which causes memory error when extract a large archive.
+
+Example to extract into network storage
+---------------------------------------
+
+Here is a pseudo code to demonstrate a way to extract contents into cloud storage.
+To simplify things in an example code, all the authentication, bucket operation,
+all the mandatory headers are omitted.
+
+
+.. code-block::
+
+    def extract_stream():
+        factory = StreamIOFactory()
+        with py7zr.SevenZipFile("target.7z") as archive:
+            archive.readall(factory=factory)
+
+
+    class StreamIO(py7zr.io.Py7zIO):
+        """Example network storage writer."""
+
+        def __init__(self, fname: str):
+            self.fname = fname
+            self.length = 0
+
+        def write(self, data: [bytes, bytearray]):
+            self.length += len(data)
+            # the py7zr will call write multiple time, so you need to append data
+            requests.put("https://your.custom.network.storage.example.com/append/to/file/command/", data=data)
+
+        def read(self, size: Optional[int] = None) -> bytes:
+            return b''
+
+        def seek(self, offset: int, whence: int = 0) -> int:
+            return offset
+
+        def flush(self) -> None:
+            pass
+
+        def size(self) -> int:
+            return self.length
+
+
+    class StreamIOFactory(py7zr.io.WriterFactory):
+        """Factory class to return StreamWriter object."""
+
+        def __init__(self):
+            self.products = {}
+
+        def create(self, filename: str) -> Py7zIO:
+            product = StreamIO(filename)
+            self.products[filename] = product
+            return product

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -7,11 +7,11 @@ Advanced usage
 Stream 7z content
 -----------------
 
-The py7zr provide a way to stream archive content with ``read`` and ``readall`` methods.
-The ``read`` and ``readall`` methods accept an object which implement ``py7zr.io.WriterFactory`` interface.
+The py7zr provide a way to stream archive content with ``extract`` and ``extractall`` methods.
+The methods accept an object which implement ``py7zr.io.WriterFactory`` interface as ``factory`` arugment.
 Your custom class which implements ``WriterFactory`` interface should have ``create`` method.
 The ``create`` method should return your custom class object which implements ``Py7zIO`` interface.
-The ``Py7zIO`` interface is mostly as same as Python Standard ``BinaryIO`` but it also have ``size`` method.
+The ``Py7zIO`` interface is as similar as Python Standard ``BinaryIO`` but it also have ``size`` method.
 
 When the py7zr extract the archive contents, it calls the factory object with filename and ask creating the io object.
 The py7zr write the io object with ``write`` method, which is as similar as an object returned by the standard ``open`` method.
@@ -19,9 +19,9 @@ The py7zr write the io object with ``write`` method, which is as similar as an o
 You can process ``write`` in your custom class. The method is called on-the-fly when the py7zr move to extract the target
 archive file.
 
-Note: Because the py7zr run in multi-threaded, your custom class should be thread-safe.
+Note: Because the py7zr may run in multi-threaded, your custom class should be thread-safe.
 
-The py7zr provide the way to stream content without buffering all the archive content in a memory, which causes memory error when extract a large archive.
+The py7zr provide the way to stream content without buffering all the archive content in a memory.
 
 Example to extract into network storage
 ---------------------------------------
@@ -36,7 +36,7 @@ all the mandatory headers are omitted.
     def extract_stream():
         factory = StreamIOFactory()
         with py7zr.SevenZipFile("target.7z") as archive:
-            archive.readall(factory=factory)
+            archive.extractall(factory=factory)
 
 
     class StreamIO(py7zr.io.Py7zIO):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -249,15 +249,16 @@ SevenZipFile Object
 
 .. code-block:: python
 
-   class MyWriter(Py7zIO):
-       def __init__(self):
+   class MyIO(Py7zIO):
+       def __init__(self, limit):
+           self.limit = limit
            self.buf = None
            self.empty = True
 
        def write(self, s: [bytes, bytearray]):
-           """keep only first 10 bytes"""
+           """keep only bytes of limit"""
            if self.empty:
-               self.buf = s[:10]
+               self.buf = s[:self.limit]
                self.empty = False
 
        def read(self, length: int = 0) -> bytes:
@@ -273,13 +274,23 @@ SevenZipFile Object
 
 
    class MyFactory(WriterFactory):
+
+       def __init(self, size):
+           self.size = size
+           self.products = {}
+
        def create(self, fname) -> Py7zIO:
-           return MyWriter()
+           product = MyIO(self.size)
+           self.products[fname] = product
+           return product
 
 
+   size = 10
+   factory = MyFactory(size)
    with SevenZipFile('archive.7z', 'r') as zip:
-       for fname, py7zio in zip.readall(MyFactory()).items():
-           print(f'{fname}: {py7zio.read(10)}...')
+       zip.readall(factory)
+   for fname in factory.products.keys():
+       print(f'{fname}: {factory.products[fname].read(size)}...')
 
 
 .. py:method:: SevenZipFile.read(factory: WriterFactory, targets=None)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -178,13 +178,11 @@ SevenZipFile Object
    encrypted archive. Otherwise return `False`
 
 
-.. py:method:: SevenZipFile.extractall(path=None)
+.. py:method:: SevenZipFile.extractall(path=None, recursive=True, *, progress_callback, factory)
 
-   Extract all members from the archive to current working directory.  *path*
-   specifies a different directory to extract to.
+   Extract all members from the archive to current working directory.
 
-
-.. py:method:: SevenZipFile.extract(path=None, targets=None)
+.. py:method:: SevenZipFile.extract(path=None, targets=None, recursive=True, *, progress_callback, factory)
 
    Extract specified pathspec archived files to current working directory.
    'path' specifies a different directory to extract to.
@@ -198,16 +196,12 @@ SevenZipFile Object
 
    Once extract() called, the ``SevenZipFile`` object become exhausted,
    and an EOF state.
-   If you want to call :meth:`read`, :meth:`readall`, :meth:`extract`, :meth:`extractall`
-   again, you should call :meth:`reset` before it.
+   If you want to call :meth:`extract`, :meth:`extractall` again, you should call :meth:`reset` before it.
 
    **CAUTION** when specifying files and not specifying parent directory,
    py7zr will fails with no such directory. When you want to extract file
    'somedir/somefile' then pass a list: ['somedirectory', 'somedir/somefile']
    as a target argument.
-
-
-.. py:method:: SevenZipFile.extract(path=None, targets=None, recursive=True)
 
    'recursive' is a BOOLEAN which if set True, helps with simplifying subcontents
    extraction.
@@ -215,13 +209,18 @@ SevenZipFile Object
    Instead of specifying all files / directories under a parent
    directory by passing a list of 'targets', specifying only the parent directory
    and setting 'recursive' to True forces an automatic extraction of all
-   subdirectories and subcontents recursively.
+   subdirectories and sub-contents recursively.
 
    If 'recursive' is not set, it defaults to False, so the extraction proceeds as
    if the parameter did not exist.
 
    Please see 'tests/test_basic.py: test_py7zr_extract_and_getnames()' for
    example code.
+
+   'progress_callback' is an object to give a extraction progress to caller.
+
+   'factory' is an object to extract user specified object other than file system.
+   When 'factory' specified, `path` is ignored. 'factory' object should implement Py7zIO interface.
 
 .. code-block:: python
 
@@ -234,18 +233,6 @@ SevenZipFile Object
    with SevenZipFile('archive.7z', 'r') as zip:
         zip.extract(targets=targets, recursive=True)
 
-
-.. py:method:: SevenZipFile.readall(factory: WriterFactory = factory)
-
-   Extract all members from the archive to object which implement Py7zIO interface,
-   and returns dictionary object which key is archived filename and value is given object
-   that factory class provide.
-
-   Returned dictionary has a form of Dict[str, Py7zIO].
-   Once readall() called, the SevenZipFIle object become exhausted and EOF state.
-   If you want to call read(), readall(), extract(), extractall() again,
-   you should call reset() before it.
-   You can get extracted data from dictionary value as such
 
 .. code-block:: python
 
@@ -288,36 +275,9 @@ SevenZipFile Object
    size = 10
    factory = MyFactory(size)
    with SevenZipFile('archive.7z', 'r') as zip:
-       zip.readall(factory)
+       zip.extractall(factory=factory)
    for fname in factory.products.keys():
        print(f'{fname}: {factory.products[fname].read(size)}...')
-
-
-.. py:method:: SevenZipFile.read(factory: WriterFactory, targets=None)
-
-   Extract specified list of target archived files to dictionary object.
-
-   'targets' is a COLLECTION of archived file names to be extracted.
-   py7zr looks for files and directories as same as specified in element
-   of 'targets'.
-
-   When the method get a ``str`` object or another object other than collection
-   such as LIST or SET, it will raise :exc:`TypeError`.
-
-   When targets is None, it behave as same as readall().
-   Once read() called, the SevenZipFIle object become exhausted and EOF state.
-   If you want to call read(), readall(), extract(), extractall() again,
-   you should call reset() before it.
-
-.. code-block:: python
-
-   filter_pattern = re.compile(r'scripts.*')
-   with SevenZipFile('archive.7z', 'r') as zip:
-        allfiles = zip.getnames()
-        targets = [f for f in allfiles if filter_pattern.match(f)]
-   with SevenZipFile('archive.7z', 'r') as zip:
-        for fname, bio in zip.read(targets).items():
-            print(f'{fname}: {bio.read(10)}...')
 
 
 .. py:method:: SevenZipFile.list()

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -33,4 +33,4 @@ Contributors, listed alphabetically, are:
 * Sergei -- Update report_update() (#558)
 * T. Yamada -- Deflate64 decompression (#399)
 * Vlad Firoiu -- Speed-up extraction when number of files is very large(#555)
-* @Zoynels -- Mmeory IO API(#111, #119)
+* @Zoynels -- BytesIO dictionary API (#111, #119) (removed in v1.0.0-rc2)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ py7zr -- a 7z library on python
    :maxdepth: 3
 
    user_guide
+   advanced
    SECURITY
    api
    contribution

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -71,7 +71,7 @@ Package               Purpose
     user try to compress/decompress with Brotli compression algorithm.
 
 .. _`issue#527`: https://github.com/miurahr/py7zr/issues/527
-.. _`Brotli Issue#782`: https://github.com/google/brotli/issues/782#issuecomment-559516099
+.. _`Brotli Issue#782`: https://github.com/google/brotli/issues/782
 
 
 Run Command

--- a/py7zr/__init__.py
+++ b/py7zr/__init__.py
@@ -18,6 +18,7 @@
 #    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 from py7zr.exceptions import Bad7zFile, DecompressionError, PasswordRequired, UnsupportedCompressionMethodError
+from py7zr.io import Py7zIO, WriterFactory
 from py7zr.properties import (
     CHECK_CRC32,
     CHECK_CRC64,
@@ -43,7 +44,6 @@ from py7zr.properties import (
     PRESET_EXTREME,
 )
 from py7zr.py7zr import ArchiveInfo, FileInfo, SevenZipFile, is_7zfile, pack_7zarchive, unpack_7zarchive
-from py7zr.io import Py7zIO, WriterFactory
 from py7zr.version import __version__
 
 __copyright__ = "Copyright (C) 2019-2021 Hiroshi Miura"

--- a/py7zr/__init__.py
+++ b/py7zr/__init__.py
@@ -43,6 +43,7 @@ from py7zr.properties import (
     PRESET_EXTREME,
 )
 from py7zr.py7zr import ArchiveInfo, FileInfo, SevenZipFile, is_7zfile, pack_7zarchive, unpack_7zarchive
+from py7zr.io import Py7zIO, WriterFactory
 from py7zr.version import __version__
 
 __copyright__ = "Copyright (C) 2019-2021 Hiroshi Miura"
@@ -60,6 +61,8 @@ __all__ = [
     "UnsupportedCompressionMethodError",
     "Bad7zFile",
     "DecompressionError",
+    "Py7zIO",
+    "WriterFactory",
     "FILTER_LZMA",
     "FILTER_LZMA2",
     "FILTER_DELTA",

--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -38,7 +38,8 @@ from Cryptodome.Cipher import AES
 from Cryptodome.Random import get_random_bytes
 
 from py7zr.exceptions import PasswordRequired, UnsupportedCompressionMethodError
-from py7zr.helpers import Buffer, calculate_crc32, calculate_key
+from py7zr.helpers import calculate_crc32, calculate_key
+from py7zr.io import Buffer
 from py7zr.properties import (
     COMPRESSION_METHOD,
     FILTER_ARM,

--- a/py7zr/helpers.py
+++ b/py7zr/helpers.py
@@ -2,7 +2,7 @@
 #
 # p7zr library
 #
-# Copyright (c) 2019-2022 Hiroshi Miura <miurahr@linux.com>
+# Copyright (c) 2019-2024 Hiroshi Miura <miurahr@linux.com>
 # Copyright (c) 2004-2015 by Joachim Bauch, mail@joachim-bauch.de
 #
 # This library is free software; you can redistribute it and/or
@@ -30,7 +30,7 @@ import sys
 import time as _time
 import zlib
 from datetime import datetime, timedelta, timezone, tzinfo
-from typing import BinaryIO, Optional, Union
+from typing import Optional, Union
 
 from py7zr import Bad7zFile
 from py7zr.win32compat import is_windows_native_python, is_windows_unc_path
@@ -288,123 +288,6 @@ def readlink(path: Union[str, pathlib.Path], *, dir_fd=None) -> Union[str, pathl
         return path.readlink()
     else:
         return os.readlink(path, dir_fd=dir_fd)
-
-
-class MemIO:
-    """pathlib.Path-like IO class to write memory(io.Bytes)"""
-
-    def __init__(self, buf: BinaryIO):
-        self._buf = buf
-
-    def write(self, data: bytes) -> int:
-        return self._buf.write(data)
-
-    def read(self, length: Optional[int] = None) -> bytes:
-        if length is not None:
-            return self._buf.read(length)
-        else:
-            return self._buf.read()
-
-    def close(self) -> None:
-        self._buf.seek(0)
-
-    def flush(self) -> None:
-        pass
-
-    def seek(self, position: int) -> None:
-        self._buf.seek(position)
-
-    def open(self, mode=None):
-        return self
-
-    @property
-    def parent(self):
-        return self
-
-    def mkdir(self, parents=None, exist_ok=False):
-        return None
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-
-class NullIO:
-    """pathlib.Path-like IO class of /dev/null"""
-
-    def __init__(self):
-        pass
-
-    def write(self, data):
-        return len(data)
-
-    def read(self, length=None):
-        if length is not None:
-            return bytes(length)
-        else:
-            return b""
-
-    def close(self):
-        pass
-
-    def flush(self):
-        pass
-
-    def open(self, mode=None):
-        return self
-
-    @property
-    def parent(self):
-        return self
-
-    def mkdir(self):
-        return None
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-
-class BufferOverflow(Exception):
-    pass
-
-
-class Buffer:
-    def __init__(self, size: int = 16):
-        self._buf = bytearray(size)
-        self._buflen = 0
-        self.view = memoryview(self._buf[0:0])
-
-    def add(self, data: Union[bytes, bytearray, memoryview]):
-        length = len(data)
-        self._buf[self._buflen :] = data
-        self._buflen += length
-        self.view = memoryview(self._buf[0 : self._buflen])
-
-    def reset(self) -> None:
-        self._buflen = 0
-        self.view = memoryview(self._buf[0:0])
-
-    def set(self, data: Union[bytes, bytearray, memoryview]) -> None:
-        length = len(data)
-        self._buf[0:] = data
-        self._buflen = length
-        self.view = memoryview(self._buf[0:length])
-
-    def get(self) -> bytearray:
-        val = self._buf[: self._buflen]
-        self.reset()
-        return val
-
-    def __len__(self) -> int:
-        return self._buflen
-
-    def __bytes__(self):
-        return bytes(self._buf[0 : self._buflen])
 
 
 def remove_relative_path_marker(path: str) -> str:

--- a/py7zr/io.py
+++ b/py7zr/io.py
@@ -104,19 +104,30 @@ class WriterFactory(ABC):
 
 class HashIOFactory(WriterFactory):
     def __init__(self):
-        pass
+        self.products = {}
 
     def create(self, filename: str) -> Py7zIO:
-        return HashIO(filename)
+        product = HashIO(filename)
+        self.products[filename] = product
+        return product
+
+    def get(self, filename: str) -> Py7zIO:
+        return self.products[filename]
 
 
 class BytesIOFactory(WriterFactory):
 
     def __init__(self, limit: int):
         self.limit = limit
+        self.products = {}
 
     def create(self, filename: str) -> Py7zIO:
-        return Py7zBytesIO(filename, self.limit)
+        product = Py7zBytesIO(filename, self.limit)
+        self.products[filename] = product
+        return product
+
+    def get(self, filename):
+        return self.products[filename]
 
 
 class NullIOFactory(WriterFactory):

--- a/py7zr/io.py
+++ b/py7zr/io.py
@@ -49,14 +49,14 @@ class HashIO(Py7zIO):
     def __init__(self, filename):
         self.filename = filename
         self.hash = hashlib.sha256()
-        self.size = 0
+        self._size: int = 0
 
     def write(self, s: Union[bytes, bytearray]) -> int:
-        self.size += len(s)
+        self._size += len(s)
         self.hash.update(s)
         return len(s)
 
-    def read(self, size: Optional[int] = None) -> bytes:
+    def read(self, length: Optional[int] = None) -> bytes:
         return self.hash.digest()
 
     def seek(self, offset: int, whence: int = 0) -> int:
@@ -66,7 +66,7 @@ class HashIO(Py7zIO):
         pass
 
     def size(self) -> int:
-        return self.size
+        return self._size
 
 
 class Py7zBytesIO(Py7zIO):
@@ -119,7 +119,7 @@ class BytesIOFactory(WriterFactory):
 
     def __init__(self, limit: int):
         self.limit = limit
-        self.products = {}
+        self.products: dict[str, Py7zBytesIO] = {}
 
     def create(self, filename: str) -> Py7zIO:
         product = Py7zBytesIO(filename, self.limit)
@@ -141,14 +141,11 @@ class NullIOFactory(WriterFactory):
 class MemIO:
     """pathlib.Path-like IO class to write memory"""
 
-    def __init__(self, fname: str, factory: Optional[WriterFactory] = None):
+    def __init__(self, fname: str, factory: WriterFactory):
         self._buf: Optional[Py7zIO] = None
         self._closed = True
         self.fname = fname
-        if factory is None:
-            self.factory: WriterFactory = BytesIOFactory()
-        else:
-            self.factory = factory
+        self.factory = factory
 
     @property
     def mode(self) -> str:
@@ -249,7 +246,7 @@ class NullIO(Py7zIO):
         return None
 
     def seek(self, offset: int, whence: int = 0) -> int:
-        pass
+        return offset
 
     def size(self):
         return 0

--- a/py7zr/io.py
+++ b/py7zr/io.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+#
+#    Pure python p7zr implementation
+#    Copyright (C) 2019-2024 Hiroshi Miura
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+import io
+from abc import ABC, abstractmethod
+from typing import Optional, Union
+
+
+class Py7zIO(ABC):
+
+    @abstractmethod
+    def write(self, s: Union[bytes, bytearray]) -> int:
+        pass
+
+    @abstractmethod
+    def read(self, size: Optional[int] = None) -> bytes:
+        pass
+
+    @abstractmethod
+    def seek(self, offset: int, whence: int = 0) -> int:
+        pass
+
+    @abstractmethod
+    def flush(self) -> None:
+        pass
+
+    @abstractmethod
+    def size(self) -> int:
+        pass
+
+
+class Py7zBytesIO(Py7zIO):
+    def __init__(self):
+        self._buffer = io.BytesIO()
+
+    def write(self, s: Union[bytes, bytearray]) -> int:
+        return self._buffer.write(s)
+
+    def read(self, size: Optional[int] = None) -> bytes:
+        return self._buffer.read(size)
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        return self._buffer.seek(offset, whence)
+
+    def flush(self) -> None:
+        return self._buffer.flush()
+
+    def size(self) -> int:
+        return self._buffer.getbuffer().nbytes
+
+
+class WriterFactory(ABC):
+
+    @abstractmethod
+    def create(self, filename: str) -> Py7zIO:
+        """request writer which compatible with BinaryIO, such as BytesIO object."""
+        pass
+
+
+class BytesIOFactory(WriterFactory):
+
+    def __init__(self):
+        pass
+
+    def create(self, filename: str) -> Py7zIO:
+        return Py7zBytesIO()
+
+
+class MemIO:
+    """pathlib.Path-like IO class to write memory"""
+
+    def __init__(self, fname: str, factory: Optional[WriterFactory] = None):
+        self._buf: Optional[Py7zIO] = None
+        self._closed = True
+        self.fname = fname
+        if factory is None:
+            self.factory: WriterFactory = BytesIOFactory()
+        else:
+            self.factory = factory
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def name(self) -> str:
+        return self.fname
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def size(self) -> int:
+        return self.__sizeof__()
+
+    def __sizeof__(self) -> int:
+        if self._buf is None:
+            return -1
+        return self._buf.size()
+
+    def flush(self) -> None:
+        if self._buf is not None:
+            self._buf.flush()
+
+    def write(self, s: Union[bytes, bytearray]) -> int:
+        if self._buf is None:
+            return -1
+        return self._buf.write(s)
+
+    def read(self, length: Optional[int] = None) -> bytes:
+        if self._buf is None:
+            return b""
+        if length is not None:
+            return self._buf.read(length)
+        else:
+            return self._buf.read()
+
+    def close(self) -> None:
+        self._closed = True
+        if self._buf is not None:
+            self._buf.seek(0)
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        if self._buf is None:
+            return -1
+        return self._buf.seek(offset, whence)
+
+    def open(self, mode: str = "w"):
+        self._mode = mode
+        self._closed = False
+        if self._buf is None:
+            self._buf = self.factory.create(self.fname)
+        else:
+            self._buf.seek(0)
+        return self
+
+    @property
+    def parent(self):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+class NullIO:
+    """pathlib.Path-like IO class of /dev/null"""
+
+    def __init__(self):
+        pass
+
+    def write(self, data):
+        return len(data)
+
+    def read(self, length=None):
+        if length is not None:
+            return bytes(length)
+        else:
+            return b""
+
+    def close(self):
+        pass
+
+    def flush(self):
+        pass
+
+    def open(self, mode=None):
+        return self
+
+    @property
+    def parent(self):
+        return self
+
+    def mkdir(self):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+class BufferOverflow(Exception):
+    pass
+
+
+class Buffer:
+    def __init__(self, size: int = 16):
+        self._buf = bytearray(size)
+        self._buflen = 0
+        self.view = memoryview(self._buf[0:0])
+
+    def add(self, data: Union[bytes, bytearray, memoryview]):
+        length = len(data)
+        self._buf[self._buflen :] = data
+        self._buflen += length
+        self.view = memoryview(self._buf[0 : self._buflen])
+
+    def reset(self) -> None:
+        self._buflen = 0
+        self.view = memoryview(self._buf[0:0])
+
+    def set(self, data: Union[bytes, bytearray, memoryview]) -> None:
+        length = len(data)
+        self._buf[0:] = data
+        self._buflen = length
+        self.view = memoryview(self._buf[0:length])
+
+    def get(self) -> bytearray:
+        val = self._buf[: self._buflen]
+        self.reset()
+        return val
+
+    def __len__(self) -> int:
+        return self._buflen
+
+    def __bytes__(self):
+        return bytes(self._buf[0 : self._buflen])

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -42,6 +42,7 @@ from shutil import ReadError
 from threading import Thread
 from typing import IO, Any, BinaryIO, Optional, Union
 
+import deprecated
 import multivolumefile
 
 from py7zr.archiveinfo import Folder, Header, SignatureHeader
@@ -1016,7 +1017,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
             )
         return alist
 
-    def readall(self, factory: Optional[WriterFactory] = None) -> Optional[dict[str, MemIO]]:
+    def readall(self, factory: WriterFactory) -> Optional[dict[str, MemIO]]:
         self._dict = {}
         return self._extract(path=None, return_dict=True, writer_factory=factory)
 
@@ -1029,8 +1030,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         self._extract(path=path, return_dict=False, callback=callback)
 
     def read(
-        self, targets: Optional[Collection[str]] = None, factory: Optional[WriterFactory] = None
-    ) -> Optional[dict[str, MemIO]]:
+        self, factory: WriterFactory, targets: Optional[Collection[str]] = None) -> Optional[dict[str, MemIO]]:
         if not self._is_none_or_collection(targets):
             raise TypeError("Wrong argument type given.")
         # For interoperability with ZipFile, we strip any trailing slashes
@@ -1106,6 +1106,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         self.files.append(file_info)
         self.worker.archive(self.fp, self.files, folder, deref=self.dereference)
 
+    @deprecated
     def writed(self, targets: dict[str, IO[Any]]) -> None:
         for target, input in targets.items():
             self.writef(input, target)

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -1022,7 +1022,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         directories afterwards. ``path`` specifies a different directory
         to extract to.
         """
-        self._extract(path=path, return_dict=False, callback=callback)
+        self._extract(path=path, callback=callback)
 
     def read(self, factory: WriterFactory, targets: Optional[Collection[str]] = None) -> None:
         if not self._is_none_or_collection(targets):
@@ -1042,7 +1042,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         # This also matches the behavior of TarFile
         if targets is not None:
             targets = [remove_trailing_slash(target) for target in targets]
-        self._extract(path, targets, return_dict=False, recursive=recursive)
+        self._extract(path, targets, recursive=recursive)
 
     def reporter(self, callback: ExtractCallback):
         while True:

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -43,7 +43,6 @@ from threading import Thread
 from typing import IO, Any, BinaryIO, Optional, Union
 
 import multivolumefile
-from deprecated import deprecated
 
 from py7zr.archiveinfo import Folder, Header, SignatureHeader
 from py7zr.callbacks import ExtractCallback
@@ -1013,7 +1012,13 @@ class SevenZipFile(contextlib.AbstractContextManager):
             )
         return alist
 
-    def extractall(self, path: Optional[Any] = None, *, callback: Optional[ExtractCallback] = None, factory: Optional[WriterFactory] = None) -> None:
+    def extractall(
+        self,
+        path: Optional[Any] = None,
+        *,
+        callback: Optional[ExtractCallback] = None,
+        factory: Optional[WriterFactory] = None,
+    ) -> None:
         """Extract all members from the archive to the current working
         directory and set owner, modification time and permissions on
         directories afterward. ``path`` specifies a different directory
@@ -1022,8 +1027,14 @@ class SevenZipFile(contextlib.AbstractContextManager):
         self._extract(path=path, callback=callback, writer_factory=factory)
 
     def extract(
-        self, path: Optional[Any] = None, targets: Optional[Collection[str]] = None, recursive: Optional[bool] = False,
-            *, callback: Optional[ExtractCallback] = None, factory: Optional[WriterFactory] = None) -> None:
+        self,
+        path: Optional[Any] = None,
+        targets: Optional[Collection[str]] = None,
+        recursive: Optional[bool] = False,
+        *,
+        callback: Optional[ExtractCallback] = None,
+        factory: Optional[WriterFactory] = None,
+    ) -> None:
         if not self._is_none_or_collection(targets):
             raise TypeError("Wrong argument type given.")
         # For interoperability with ZipFile, we strip any trailing slashes

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -535,11 +535,10 @@ class SevenZipFile(contextlib.AbstractContextManager):
         self,
         path: Optional[Any] = None,
         targets: Optional[Collection[str]] = None,
-        return_dict: bool = False,
         callback: Optional[ExtractCallback] = None,
         recursive: Optional[bool] = False,
         writer_factory: Optional[WriterFactory] = None,
-    ) -> Optional[dict[str, MemIO]]:
+    ) -> None:
         if callback is None:
             pass
         elif isinstance(callback, ExtractCallback):

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -42,8 +42,8 @@ from shutil import ReadError
 from threading import Thread
 from typing import IO, Any, BinaryIO, Optional, Union
 
-from deprecated import deprecated
 import multivolumefile
+from deprecated import deprecated
 
 from py7zr.archiveinfo import Folder, Header, SignatureHeader
 from py7zr.callbacks import ExtractCallback
@@ -1024,8 +1024,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         """
         self._extract(path=path, return_dict=False, callback=callback)
 
-    def read(
-        self, factory: WriterFactory, targets: Optional[Collection[str]] = None) -> None:
+    def read(self, factory: WriterFactory, targets: Optional[Collection[str]] = None) -> None:
         if not self._is_none_or_collection(targets):
             raise TypeError("Wrong argument type given.")
         # For interoperability with ZipFile, we strip any trailing slashes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
       "pybcj>=1.0.0,<1.1.0",
       "multivolumefile>=0.2.3",
       "inflate64>=1.0.0,<1.1.0",
-      "Deprecated",
 ]
 keywords = ['compression', '7zip', 'lzma', 'zstandard', 'ppmd', 'lzma2', 'bcj', 'archive']
 dynamic = ["readme", "version"]
@@ -88,7 +87,6 @@ check = [
       "readme-renderer",
       "twine",
       "black>=24.8.0",
-      "types-Deprecated"
 ]
 debug = [
       "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
       "pybcj>=1.0.0,<1.1.0",
       "multivolumefile>=0.2.3",
       "inflate64>=1.0.0,<1.1.0",
+      "deprecated",
 ]
 keywords = ['compression', '7zip', 'lzma', 'zstandard', 'ppmd', 'lzma2', 'bcj', 'archive']
 dynamic = ["readme", "version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ test = [
       "coverage[toml]>=5.2",
       "coveralls>=2.1.1",
       "requests",
-      "pytest-httpserver"
+      "pytest-httpserver",
 ]
 docs = [
       "sphinx>=7.0.0",
@@ -88,6 +88,7 @@ check = [
       "readme-renderer",
       "twine",
       "black>=24.8.0",
+      "types-Deprecated"
 ]
 debug = [
       "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
       "pybcj>=1.0.0,<1.1.0",
       "multivolumefile>=0.2.3",
       "inflate64>=1.0.0,<1.1.0",
-      "deprecated",
+      "Deprecated",
 ]
 keywords = ['compression', '7zip', 'lzma', 'zstandard', 'ppmd', 'lzma2', 'bcj', 'archive']
 dynamic = ["readme", "version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ test = [
       "py-cpuinfo",
       "coverage[toml]>=5.2",
       "coveralls>=2.1.1",
+      "requests",
+      "pytest-httpserver"
 ]
 docs = [
       "sphinx>=7.0.0",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -272,7 +272,7 @@ def test_py7zr_read_and_reset(tmp_path):
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "read_reset.7z"), "rb"))
     iterations = archive.getnames()
     for target in iterations:
-        _dict = archive.read(targets=[target])
+        _dict = archive.read(factory=py7zr.io.NullIOFactory(), targets=[target])
         assert len(_dict) == 1
         archive.reset()
     archive.close()
@@ -283,7 +283,7 @@ def test_py7zr_read_with_trailing_slash_and_reset(tmp_path):
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "read_reset.7z"), "rb"))
     iterations = archive.getnames()
     for target in iterations:
-        _dict = archive.read(targets=[f"{target}/"])
+        _dict = archive.read(factory=py7zr.io.NullIOFactory(), targets=[f"{target}/"])
         assert len(_dict) == 1
         archive.reset()
     archive.close()
@@ -348,21 +348,22 @@ def test_read_collection_argument():
         "HmmmTaSI/atXtuwiN5mGrqyFZTC/V2VEohWua1Yk1K+jXy+32hBwnK2clyr3rN5L"
         "Abv5g2wXBiABCYCFAAcLAQABIwMBAQVdABAAAAyAlgoBouB4BAAA"
     )
+    factory = py7zr.io.BytesIOFactory(64)
     with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-        result = arc.read(["bar.txt"])  # list -> ok
+        result = arc.read(factory, ["bar.txt"])  # list -> ok
         assert "bar.txt" in result
         bina = result.get("bar.txt")
         assert isinstance(bina, MemIO)
         assert bina.read() == b"refinery"
     with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-        result = arc.read({"bar.txt"})  # set -> ok
+        result = arc.read(factory, {"bar.txt"})  # set -> ok
         assert result.get("bar.txt").read() == b"refinery"
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-            arc.read(("bar.txt",))  # tuple -> bad
+            arc.read(factory, ("bar.txt",))  # tuple -> bad
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-            arc.read("bar.txt")  # str -> bad
+            arc.read(factory, "bar.txt")  # str -> bad
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
             arc.extract(targets="bar.txt")  # str -> bad

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,6 +12,7 @@ import py7zr.archiveinfo
 import py7zr.callbacks
 import py7zr.cli
 import py7zr.properties
+from py7zr.io import MemIO
 
 from . import check_output, decode_all
 
@@ -351,7 +352,7 @@ def test_read_collection_argument():
         result = arc.read(["bar.txt"])  # list -> ok
         assert "bar.txt" in result
         bina = result.get("bar.txt")
-        assert isinstance(bina, BytesIO)
+        assert isinstance(bina, MemIO)
         assert bina.read() == b"refinery"
     with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
         result = arc.read({"bar.txt"})  # set -> ok

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,7 +12,6 @@ import py7zr.archiveinfo
 import py7zr.callbacks
 import py7zr.cli
 import py7zr.properties
-from py7zr.io import MemIO
 
 from . import check_output, decode_all
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -271,7 +271,7 @@ def test_py7zr_read_and_reset(tmp_path):
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "read_reset.7z"), "rb"))
     iterations = archive.getnames()
     for target in iterations:
-        archive.read(factory=py7zr.io.NullIOFactory(), targets=[target])
+        archive.extract(targets=[target], factory=py7zr.io.NullIOFactory())
         archive.reset()
     archive.close()
 
@@ -281,7 +281,7 @@ def test_py7zr_read_with_trailing_slash_and_reset(tmp_path):
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "read_reset.7z"), "rb"))
     iterations = archive.getnames()
     for target in iterations:
-        archive.read(factory=py7zr.io.NullIOFactory(), targets=[f"{target}/"])
+        archive.extract(targets=[f"{target}/"], factory=py7zr.io.NullIOFactory())
         archive.reset()
     archive.close()
 
@@ -347,19 +347,19 @@ def test_read_collection_argument():
     )
     factory = py7zr.io.BytesIOFactory(64)
     with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-        arc.read(factory, ["bar.txt"])  # list -> ok
+        arc.extract(targets=["bar.txt"], factory=factory)  # list -> ok
         assert "bar.txt" in factory.products
         bina = factory.get("bar.txt")
         assert bina.read() == b"refinery"
     with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-        arc.read(factory, {"bar.txt"})  # set -> ok
+        arc.extract(targets={"bar.txt"}, factory=factory)  # set -> ok
         assert factory.get("bar.txt").read() == b"refinery"
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-            arc.read(factory, ("bar.txt",))  # tuple -> bad
+            arc.extract(targets=("bar.txt",), factory=factory)  # tuple -> bad
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-            arc.read(factory, "bar.txt")  # str -> bad
+            arc.extract(targets="bar.txt", factory=factory)  # str -> bad
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
             arc.extract(targets="bar.txt")  # str -> bad

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -272,8 +272,7 @@ def test_py7zr_read_and_reset(tmp_path):
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "read_reset.7z"), "rb"))
     iterations = archive.getnames()
     for target in iterations:
-        _dict = archive.read(factory=py7zr.io.NullIOFactory(), targets=[target])
-        assert len(_dict) == 1
+        archive.read(factory=py7zr.io.NullIOFactory(), targets=[target])
         archive.reset()
     archive.close()
 
@@ -283,8 +282,7 @@ def test_py7zr_read_with_trailing_slash_and_reset(tmp_path):
     archive = py7zr.SevenZipFile(open(os.path.join(testdata_path, "read_reset.7z"), "rb"))
     iterations = archive.getnames()
     for target in iterations:
-        _dict = archive.read(factory=py7zr.io.NullIOFactory(), targets=[f"{target}/"])
-        assert len(_dict) == 1
+        archive.read(factory=py7zr.io.NullIOFactory(), targets=[f"{target}/"])
         archive.reset()
     archive.close()
 
@@ -350,14 +348,13 @@ def test_read_collection_argument():
     )
     factory = py7zr.io.BytesIOFactory(64)
     with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-        result = arc.read(factory, ["bar.txt"])  # list -> ok
-        assert "bar.txt" in result
-        bina = result.get("bar.txt")
-        assert isinstance(bina, MemIO)
+        arc.read(factory, ["bar.txt"])  # list -> ok
+        assert "bar.txt" in factory.products
+        bina = factory.get("bar.txt")
         assert bina.read() == b"refinery"
     with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
-        result = arc.read(factory, {"bar.txt"})  # set -> ok
-        assert result.get("bar.txt").read() == b"refinery"
+        arc.read(factory, {"bar.txt"})  # set -> ok
+        assert factory.get("bar.txt").read() == b"refinery"
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(BytesIO(data), password="boom") as arc:
             arc.read(factory, ("bar.txt",))  # tuple -> bad

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -28,7 +28,7 @@ def test_extract_encrypted_1(tmp_path):
 @pytest.mark.files
 def test_extract_encrypted_1_mem():
     archive = py7zr.SevenZipFile(testdata_path.joinpath("encrypted_1.7z").open(mode="rb"), password="secret")
-    archive.readall(py7zr.io.NullIOFactory())
+    archive.extractall(factory=py7zr.io.NullIOFactory())
     archive.close()
 
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -28,7 +28,7 @@ def test_extract_encrypted_1(tmp_path):
 @pytest.mark.files
 def test_extract_encrypted_1_mem():
     archive = py7zr.SevenZipFile(testdata_path.joinpath("encrypted_1.7z").open(mode="rb"), password="secret")
-    _dict = archive.readall()
+    archive.readall(py7zr.io.NullIOFactory())
     archive.close()
 
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -51,7 +51,7 @@ def check_archive(archive, tmp_path, return_dict: bool):
         assert tmp_path.joinpath("test1.txt").open("rb").read() == bytes("This file is located in the root.", "ascii")
     else:
         factory = py7zr.io.BytesIOFactory(64)
-        archive.readall(factory)
+        archive.extractall(factory=factory)
         actual = factory.get("test/test2.txt").read()
         assert actual == bytes("This file is located in a folder.", "ascii")
         actual = factory.get("test1.txt").read()
@@ -93,7 +93,7 @@ def test_github_14(tmp_path):
 def test_github_14_mem(tmp_path):
     archive = py7zr.SevenZipFile(testdata_path.joinpath("github_14.7z").open(mode="rb"))
     factory = py7zr.io.BytesIOFactory(limit=32)
-    archive.readall(factory)
+    archive.extractall(factory=factory)
     actual = factory.get("github_14").read()
     assert actual == bytes("Hello GitHub issue #14.\n", "ascii")
 
@@ -108,7 +108,7 @@ def _test_umlaut_archive(filename: str, target: pathlib.Path, return_dict: bool)
         assert actual == "This file contains a german umlaut in the filename."
     else:
         factory = py7zr.io.BytesIOFactory(64)
-        archive.readall(factory)
+        archive.extractall(factory=factory)
         actual = factory.products["t\xe4st.txt"].read()
         assert actual == b"This file contains a german umlaut in the filename."
     archive.close()
@@ -191,7 +191,7 @@ def test_extract_symlink(tmp_path):
 @pytest.mark.files
 def test_extract_symlink_mem():
     with py7zr.SevenZipFile(testdata_path.joinpath("symlink.7z").open(mode="rb")) as archive:
-        archive.readall(py7zr.io.NullIOFactory())
+        archive.extractall(factory=py7zr.io.NullIOFactory())
 
 
 @pytest.mark.files
@@ -252,7 +252,7 @@ def test_lzma2bcj_mem():
         "mingw64/bin/libszip-0.dll",
     ]
     factory = py7zr.io.HashIOFactory()
-    archive.readall(factory)
+    archive.extractall(factory=factory)
     digest = factory.products["mingw64/bin/libszip-0.dll"].read()
     assert digest == binascii.unhexlify("13926e3f080c9ca557165864ce5722acc4f832bb52a92d8d86c7f6e583708c4d")
     archive.close()
@@ -289,7 +289,7 @@ def test_extract_lzma_1(tmp_path):
 def test_extract_lzma2_1(tmp_path):
     with testdata_path.joinpath("lzma2_1.7z").open(mode="rb") as target:
         with py7zr.SevenZipFile(target) as ar:
-            ar.readall(py7zr.io.NullIOFactory())
+            ar.extractall(factory=py7zr.io.NullIOFactory())
 
 
 @pytest.mark.files
@@ -304,7 +304,7 @@ def test_zerosize(tmp_path):
 def test_zerosize_mem():
     with testdata_path.joinpath("zerosize.7z").open(mode="rb") as target:
         archive = py7zr.SevenZipFile(target)
-        archive.readall(py7zr.io.NullIOFactory())
+        archive.extractall(factory=py7zr.io.NullIOFactory())
         archive.close()
 
 
@@ -363,7 +363,7 @@ def test_github_14_multi_mem():
     archive = py7zr.SevenZipFile(str(testdata_path.joinpath("github_14_multi.7z")), "r")
     assert archive.getnames() == ["github_14_multi", "github_14_multi"]
     factory = py7zr.io.BytesIOFactory(32)
-    archive.readall(factory)
+    archive.extractall(factory=factory)
     actual_1 = factory.get("github_14_multi").read()
     assert actual_1 == bytes("Hello GitHub issue #14 1/2.\n", "ascii")
     actual_2 = factory.get("github_14_multi_0").read()
@@ -385,7 +385,7 @@ def test_multiblock(tmp_path):
 def test_multiblock_mem():
     archive = py7zr.SevenZipFile(testdata_path.joinpath("mblock_1.7z").open(mode="rb"))
     factory = py7zr.io.HashIOFactory()
-    archive.readall(factory)
+    archive.extractall(factory=factory)
     digest = factory.products["bin/7zdec.exe"].read()
     assert digest == binascii.unhexlify("e14d8201c5c0d1049e717a63898a3b1c7ce4054a24871daebaa717da64dcaff5")
     archive.close()
@@ -455,7 +455,7 @@ def test_no_main_streams(tmp_path):
 @pytest.mark.files
 def test_no_main_streams_mem():
     archive = py7zr.SevenZipFile(testdata_path.joinpath("test_folder.7z").open(mode="rb"))
-    archive.readall(py7zr.io.NullIOFactory())
+    archive.extractall(factory=py7zr.io.NullIOFactory())
     archive.close()
 
 
@@ -541,7 +541,7 @@ def test_decompress_small_files(tmp_path):
 @pytest.mark.files
 def test_extract_lzma_bcj_x86(tmp_path):
     with py7zr.SevenZipFile(testdata_path.joinpath("lzma_bcj_x86.7z").open(mode="rb")) as ar:
-        ar.readall(py7zr.io.NullIOFactory())
+        ar.extractall(tmp_path)
 
 
 @pytest.mark.files
@@ -609,7 +609,7 @@ def test_extract_root_path_arcname(tmp_path):
         assert len(iterations) == 1
 
         factory = py7zr.io.BytesIOFactory(32)
-        archive.read(factory=factory, targets=iterations)
+        archive.extract(targets=iterations, factory=factory)
         assert len(factory.products) == 1
         assert filename in factory.products.keys()
         assert factory.products[filename].read() == content

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -50,10 +50,11 @@ def check_archive(archive, tmp_path, return_dict: bool):
         assert tmp_path.joinpath("test/test2.txt").open("rb").read() == bytes("This file is located in a folder.", "ascii")
         assert tmp_path.joinpath("test1.txt").open("rb").read() == bytes("This file is located in the root.", "ascii")
     else:
-        _dict = archive.readall(py7zr.io.BytesIOFactory(64))
-        actual = _dict["test/test2.txt"].read()
+        factory = py7zr.io.BytesIOFactory(64)
+        archive.readall(factory)
+        actual = factory.get("test/test2.txt").read()
         assert actual == bytes("This file is located in a folder.", "ascii")
-        actual = _dict["test1.txt"].read()
+        actual = factory.get("test1.txt").read()
         assert actual == bytes("This file is located in the root.", "ascii")
     archive.close()
 
@@ -91,8 +92,9 @@ def test_github_14(tmp_path):
 @pytest.mark.files
 def test_github_14_mem(tmp_path):
     archive = py7zr.SevenZipFile(testdata_path.joinpath("github_14.7z").open(mode="rb"))
-    _dict = archive.readall(py7zr.io.BytesIOFactory(limit=32))
-    actual = _dict["github_14"].read()
+    factory = py7zr.io.BytesIOFactory(limit=32)
+    archive.readall(factory)
+    actual = factory.get("github_14").read()
     assert actual == bytes("Hello GitHub issue #14.\n", "ascii")
 
 
@@ -105,8 +107,9 @@ def _test_umlaut_archive(filename: str, target: pathlib.Path, return_dict: bool)
         actual = target.joinpath("t\xe4st.txt").open().read()
         assert actual == "This file contains a german umlaut in the filename."
     else:
-        _dict = archive.readall(py7zr.io.BytesIOFactory(64))
-        actual = _dict["t\xe4st.txt"].read()
+        factory = py7zr.io.BytesIOFactory(64)
+        archive.readall(factory)
+        actual = factory.products["t\xe4st.txt"].read()
         assert actual == b"This file contains a german umlaut in the filename."
     archive.close()
 
@@ -248,8 +251,9 @@ def test_lzma2bcj_mem():
         "mingw64/share/doc/szip/RELEASE.txt",
         "mingw64/bin/libszip-0.dll",
     ]
-    _dict = archive.readall(py7zr.io.HashIOFactory())
-    digest = _dict["mingw64/bin/libszip-0.dll"].read()
+    factory = py7zr.io.HashIOFactory()
+    archive.readall(factory)
+    digest = factory.products["mingw64/bin/libszip-0.dll"].read()
     assert digest == binascii.unhexlify("13926e3f080c9ca557165864ce5722acc4f832bb52a92d8d86c7f6e583708c4d")
     archive.close()
 
@@ -285,7 +289,7 @@ def test_extract_lzma_1(tmp_path):
 def test_extract_lzma2_1(tmp_path):
     with testdata_path.joinpath("lzma2_1.7z").open(mode="rb") as target:
         with py7zr.SevenZipFile(target) as ar:
-            _dict = ar.readall(py7zr.io.NullIOFactory())
+            ar.readall(py7zr.io.NullIOFactory())
 
 
 @pytest.mark.files
@@ -358,10 +362,11 @@ def test_github_14_multi_mem():
     """multiple unnamed objects."""
     archive = py7zr.SevenZipFile(str(testdata_path.joinpath("github_14_multi.7z")), "r")
     assert archive.getnames() == ["github_14_multi", "github_14_multi"]
-    _dict = archive.readall(py7zr.io.BytesIOFactory(32))
-    actual_1 = _dict["github_14_multi"].read()
+    factory = py7zr.io.BytesIOFactory(32)
+    archive.readall(factory)
+    actual_1 = factory.get("github_14_multi").read()
     assert actual_1 == bytes("Hello GitHub issue #14 1/2.\n", "ascii")
-    actual_2 = _dict["github_14_multi_0"].read()
+    actual_2 = factory.get("github_14_multi_0").read()
     assert actual_2 == bytes("Hello GitHub issue #14 2/2.\n", "ascii")
     archive.close()
 
@@ -379,8 +384,9 @@ def test_multiblock(tmp_path):
 @pytest.mark.files
 def test_multiblock_mem():
     archive = py7zr.SevenZipFile(testdata_path.joinpath("mblock_1.7z").open(mode="rb"))
-    _dict = archive.readall(py7zr.io.HashIOFactory())
-    digest = _dict["bin/7zdec.exe"].read()
+    factory = py7zr.io.HashIOFactory()
+    archive.readall(factory)
+    digest = factory.products["bin/7zdec.exe"].read()
     assert digest == binascii.unhexlify("e14d8201c5c0d1049e717a63898a3b1c7ce4054a24871daebaa717da64dcaff5")
     archive.close()
 
@@ -602,14 +608,11 @@ def test_extract_root_path_arcname(tmp_path):
         iterations = archive.getnames()
         assert len(iterations) == 1
 
-        _dict = archive.read(factory=py7zr.io.BytesIOFactory(32), targets=iterations)
-        if _dict is None:
-            # fix typing errors
-            raise RuntimeError("Failed to read archive")
-
-        assert len(_dict) == 1
-        assert [*_dict.keys()] == [filename]
-        assert _dict[filename].read() == content
+        factory = py7zr.io.BytesIOFactory(32)
+        archive.read(factory=factory, targets=iterations)
+        assert len(factory.products) == 1
+        assert filename in factory.products.keys()
+        assert factory.products[filename].read() == content
 
     with py7zr.SevenZipFile(filename_7z, "r") as archive:
         archive.extractall(path=tmp_path)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -86,48 +86,6 @@ def test_bcj_file(tmp_path):
         libarchive_extract(target, tmp_path / "tgt2")
 
 
-class TestArchiveWriter(py7zr.io.Py7zIO):
-
-    def __init__(self, fname, target: SevenZipFile):
-        self.fname = fname
-        self.target = target
-        self.buffer = io.BytesIO()
-
-    def write(self, s: Union[bytes, bytearray]) -> int:
-        self.buffer.write(s)
-
-    def read(self, size: Optional[int] = None) -> bytes:
-        return self.buffer.read(size)
-
-    def seek(self, offset: int, whence: int = 0) -> int:
-        return self.buffer.seek(offset, whence)
-
-    def flush(self) -> None:
-        pass
-
-    def close(self) -> None:
-        self.target.writef(self.buffer, self.fname)
-
-    def size(self) -> int:
-        return self.buffer.getbuffer().nbytes
-
-
-class TestWriterFactory(py7zr.io.WriterFactory):
-    def __init__(self, target: SevenZipFile):
-        self.target = target
-
-    def create(self, filename: str) -> py7zr.io.Py7zIO:
-        return TestArchiveWriter(filename, self.target)
-
-
-@pytest.mark.files
-def test_read_write_new(tmp_path):
-    with py7zr.SevenZipFile(tmp_path.joinpath("target.7z"), "w") as target:
-        with py7zr.SevenZipFile(testdata_path.joinpath("mblock_1.7z").open(mode="rb")) as source:
-            source.readall(TestWriterFactory(target))
-    p7zip_test(tmp_path / "target.7z")
-
-
 @pytest.mark.files
 @pytest.mark.skipif(
     sys.platform.startswith("win") and (ctypes.windll.shell32.IsUserAnAdmin() == 0),

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -96,24 +96,25 @@ def test_double_extract_symlink(tmp_path):
         archive.extractall(path=tmp_path)
 
 
-class callback(py7zr.callbacks.ExtractCallback):
+class ProgressCallbackExample(py7zr.callbacks.ExtractCallback):
     def __init__(self):
         pass
 
 
 def test_callback_raw_class():
     # test the case when passed argument is class name.
+    # it is wrong, so it become the error.
     with pytest.raises(ValueError):
         with py7zr.SevenZipFile(testdata_path.joinpath("solid.7z").open(mode="rb")) as z:
-            z.extractall(None, callback)
+            z.extractall(None, callback=ProgressCallbackExample)
 
 
 def test_callback_not_concrete_class():
     # test the case when passed argument is abstract class
     with pytest.raises(TypeError):
         with py7zr.SevenZipFile(testdata_path.joinpath("solid.7z").open(mode="rb")) as z:
-            cb = callback()
-            z.extractall(None, cb)
+            cb = ProgressCallbackExample()
+            z.extractall(None, callback=cb)
 
 
 @pytest.mark.api

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -6,11 +6,13 @@ import shutil
 import subprocess
 import sys
 from contextlib import contextmanager
+from typing import Optional, Union
 
 import multivolumefile
 import pytest
 
 import py7zr
+from py7zr import SevenZipFile
 
 from . import libarchive_extract, p7zip_test
 
@@ -84,11 +86,45 @@ def test_bcj_file(tmp_path):
         libarchive_extract(target, tmp_path / "tgt2")
 
 
+class TestArchiveWriter(py7zr.io.Py7zIO):
+
+    def __init__(self, fname, target: SevenZipFile):
+        self.fname = fname
+        self.target = target
+        self.buffer = io.BytesIO()
+
+    def write(self, s: Union[bytes, bytearray]) -> int:
+        self.buffer.write(s)
+
+    def read(self, size: Optional[int] = None) -> bytes:
+        return self.buffer.read(size)
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        return self.buffer.seek(offset, whence)
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.target.writef(self.buffer, self.fname)
+
+    def size(self) -> int:
+        return self.buffer.getbuffer().nbytes
+
+
+class TestWriterFactory(py7zr.io.WriterFactory):
+    def __init__(self, target: SevenZipFile):
+        self.target = target
+
+    def create(self, filename: str) -> py7zr.io.Py7zIO:
+        return TestArchiveWriter(filename, self.target)
+
+
 @pytest.mark.files
-def test_read_writed(tmp_path):
+def test_read_write_new(tmp_path):
     with py7zr.SevenZipFile(tmp_path.joinpath("target.7z"), "w") as target:
         with py7zr.SevenZipFile(testdata_path.joinpath("mblock_1.7z").open(mode="rb")) as source:
-            target.writed(source.readall())
+            source.readall(TestWriterFactory(target))
     p7zip_test(tmp_path / "target.7z")
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -6,13 +6,11 @@ import shutil
 import subprocess
 import sys
 from contextlib import contextmanager
-from typing import Optional, Union
 
 import multivolumefile
 import pytest
 
 import py7zr
-from py7zr import SevenZipFile
 
 from . import libarchive_extract, p7zip_test
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,64 @@
+import os
+import pathlib
+from typing import Optional
+
+import requests
+from pytest_httpserver import HTTPServer
+
+import py7zr
+import py7zr.io
+from py7zr.io import Py7zIO
+
+testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
+os.umask(0o022)
+
+
+def test_extract_stream(tmp_path, httpserver: HTTPServer):
+    httpserver.expect_request("/setup.cfg", method="PUT").respond_with_data("ok")
+    httpserver.expect_request("/setup.py", method="PUT").respond_with_data("ok")
+    httpserver.expect_request("/scripts/py7zr", method="PUT").respond_with_data("ok")
+    factory = StreamWriterFactory(httpserver)
+    with py7zr.SevenZipFile(testdata_path.joinpath("test_1.7z").open(mode="rb")) as archive:
+        archive.readall(factory=factory)
+    assert len(factory.debug_info) == 3
+    assert "setup.cfg" in factory.debug_info
+    assert "setup.py" in factory.debug_info
+    assert "scripts/py7zr" in factory.debug_info
+
+
+class StreamWriter(py7zr.io.Py7zIO):
+    """Pseudo object storage writer."""
+
+    def __init__(self, httpserver: HTTPServer, fname: str):
+        self.httpserver: HTTPServer = httpserver
+        self.fname = fname
+        self.length = 0
+
+    def write(self, data: [bytes, bytearray]):
+        self.length += len(data)
+        requests.put(self.httpserver.url_for(self.fname), data=data)
+        self.httpserver.check_assertions()
+
+    def read(self, size: Optional[int] = None) -> bytes:
+        return b"pseudo"
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        return offset
+
+    def flush(self) -> None:
+        pass
+
+    def size(self) -> int:
+        return self.length
+
+
+class StreamWriterFactory(py7zr.io.WriterFactory):
+    """Factory class to return StreamWriter object."""
+
+    def __init__(self, httpserver: HTTPServer):
+        self.httpserver: HTTPServer = httpserver
+        self.debug_info = []
+
+    def create(self, filename: str) -> Py7zIO:
+        self.debug_info.append(filename)
+        return StreamWriter(self.httpserver, filename)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -53,5 +53,5 @@ class TestWriterFactory(py7zr.io.WriterFactory):
 def test_read_write_new(tmp_path):
     with py7zr.SevenZipFile(tmp_path.joinpath("target.7z"), "w") as target:
         with py7zr.SevenZipFile(testdata_path.joinpath("mblock_1.7z").open(mode="rb")) as source:
-            source.readall(TestWriterFactory(target))
+            source.extractall(factory=TestWriterFactory(target))
     p7zip_test(tmp_path / "target.7z")

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -8,6 +8,7 @@ import pytest
 import py7zr
 import py7zr.io
 from py7zr import SevenZipFile
+
 from . import p7zip_test
 
 testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
@@ -54,4 +55,3 @@ def test_read_write_new(tmp_path):
         with py7zr.SevenZipFile(testdata_path.joinpath("mblock_1.7z").open(mode="rb")) as source:
             source.readall(TestWriterFactory(target))
     p7zip_test(tmp_path / "target.7z")
-

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,3 +1,4 @@
+import io
 import os
 import pathlib
 from typing import Optional
@@ -13,40 +14,56 @@ testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
 os.umask(0o022)
 
 
-def test_extract_stream(tmp_path, httpserver: HTTPServer):
+def test_extract_stream(httpserver: HTTPServer):
     httpserver.expect_request("/setup.cfg", method="PUT").respond_with_data("ok")
+    httpserver.expect_request("/setup.cfg", method="GET").respond_with_data("dummy data")
     httpserver.expect_request("/setup.py", method="PUT").respond_with_data("ok")
     httpserver.expect_request("/scripts/py7zr", method="PUT").respond_with_data("ok")
     factory = StreamWriterFactory(httpserver)
     with py7zr.SevenZipFile(testdata_path.joinpath("test_1.7z").open(mode="rb")) as archive:
-        archive.readall(factory=factory)
+        result = archive.readall(factory=factory)
     assert len(factory.debug_info) == 3
     assert "setup.cfg" in factory.debug_info
     assert "setup.py" in factory.debug_info
     assert "scripts/py7zr" in factory.debug_info
+    assert result["setup.cfg"].read() == b"[flake8]\nmax-line-length = 125\n\n[bdist_wheel]\nuniversal=1\n"
+
+
+def test_extract_stream_create_traditional(tmp_path, httpserver: HTTPServer):
+    httpserver.expect_request("/setup.cfg", method="PUT").respond_with_data("ok")
+    httpserver.expect_request("/setup.py", method="PUT").respond_with_data("ok")
+    httpserver.expect_request("/scripts/py7zr", method="PUT").respond_with_data("ok")
+    factory = StreamWriterFactory(httpserver)
+    with py7zr.SevenZipFile(tmp_path.joinpath("target.7z"), "w") as target:
+        with py7zr.SevenZipFile(testdata_path.joinpath("test_1.7z").open(mode="rb")) as source:
+            target.writed(source.readall(factory=factory))
 
 
 class StreamWriter(py7zr.io.Py7zIO):
     """Pseudo object storage writer."""
 
     def __init__(self, httpserver: HTTPServer, fname: str):
-        self.httpserver: HTTPServer = httpserver
+        self.buf = io.BytesIO()  # for test
+        self.httpserver: HTTPServer = httpserver  # for test
         self.fname = fname
         self.length = 0
 
     def write(self, data: [bytes, bytearray]):
         self.length += len(data)
+        self.buf.write(data)
         requests.put(self.httpserver.url_for(self.fname), data=data)
         self.httpserver.check_assertions()
 
     def read(self, size: Optional[int] = None) -> bytes:
-        return b"pseudo"
+        # This may read from other than memory.
+        # Here is a stub using BytesIO for test
+        return self.buf.read(size)
 
     def seek(self, offset: int, whence: int = 0) -> int:
-        return offset
+        return self.buf.seek(offset, whence)  # for test
 
     def flush(self) -> None:
-        pass
+        self.buf.flush()  # for test
 
     def size(self) -> int:
         return self.length
@@ -57,7 +74,7 @@ class StreamWriterFactory(py7zr.io.WriterFactory):
 
     def __init__(self, httpserver: HTTPServer):
         self.httpserver: HTTPServer = httpserver
-        self.debug_info = []
+        self.debug_info = []  # for test
 
     def create(self, filename: str) -> Py7zIO:
         self.debug_info.append(filename)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,81 +1,57 @@
 import io
 import os
 import pathlib
-from typing import Optional
+from typing import Optional, Union
 
-import requests
-from pytest_httpserver import HTTPServer
+import pytest
 
 import py7zr
 import py7zr.io
-from py7zr.io import Py7zIO
+from py7zr import SevenZipFile
+from . import p7zip_test
 
 testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
 os.umask(0o022)
 
 
-def test_extract_stream(httpserver: HTTPServer):
-    httpserver.expect_request("/setup.cfg", method="PUT").respond_with_data("ok")
-    httpserver.expect_request("/setup.cfg", method="GET").respond_with_data("dummy data")
-    httpserver.expect_request("/setup.py", method="PUT").respond_with_data("ok")
-    httpserver.expect_request("/scripts/py7zr", method="PUT").respond_with_data("ok")
-    factory = StreamWriterFactory(httpserver)
-    with py7zr.SevenZipFile(testdata_path.joinpath("test_1.7z").open(mode="rb")) as archive:
-        result = archive.readall(factory=factory)
-    assert len(factory.debug_info) == 3
-    assert "setup.cfg" in factory.debug_info
-    assert "setup.py" in factory.debug_info
-    assert "scripts/py7zr" in factory.debug_info
-    assert result["setup.cfg"].read() == b"[flake8]\nmax-line-length = 125\n\n[bdist_wheel]\nuniversal=1\n"
+class TestArchiveWriter(py7zr.io.Py7zIO):
 
-
-def test_extract_stream_create_traditional(tmp_path, httpserver: HTTPServer):
-    httpserver.expect_request("/setup.cfg", method="PUT").respond_with_data("ok")
-    httpserver.expect_request("/setup.py", method="PUT").respond_with_data("ok")
-    httpserver.expect_request("/scripts/py7zr", method="PUT").respond_with_data("ok")
-    factory = StreamWriterFactory(httpserver)
-    with py7zr.SevenZipFile(tmp_path.joinpath("target.7z"), "w") as target:
-        with py7zr.SevenZipFile(testdata_path.joinpath("test_1.7z").open(mode="rb")) as source:
-            target.writed(source.readall(factory=factory))
-
-
-class StreamWriter(py7zr.io.Py7zIO):
-    """Pseudo object storage writer."""
-
-    def __init__(self, httpserver: HTTPServer, fname: str):
-        self.buf = io.BytesIO()  # for test
-        self.httpserver: HTTPServer = httpserver  # for test
+    def __init__(self, fname, target: SevenZipFile):
         self.fname = fname
-        self.length = 0
+        self.target = target
+        self.buffer = io.BytesIO()
 
-    def write(self, data: [bytes, bytearray]):
-        self.length += len(data)
-        self.buf.write(data)
-        requests.put(self.httpserver.url_for(self.fname), data=data)
-        self.httpserver.check_assertions()
+    def write(self, s: Union[bytes, bytearray]) -> int:
+        return self.buffer.write(s)
 
     def read(self, size: Optional[int] = None) -> bytes:
-        # This may read from other than memory.
-        # Here is a stub using BytesIO for test
-        return self.buf.read(size)
+        return self.buffer.read(size)
 
     def seek(self, offset: int, whence: int = 0) -> int:
-        return self.buf.seek(offset, whence)  # for test
+        return self.buffer.seek(offset, whence)
 
     def flush(self) -> None:
-        self.buf.flush()  # for test
+        pass
+
+    def close(self) -> None:
+        self.target.writef(self.buffer, self.fname)
 
     def size(self) -> int:
-        return self.length
+        return self.buffer.getbuffer().nbytes
 
 
-class StreamWriterFactory(py7zr.io.WriterFactory):
-    """Factory class to return StreamWriter object."""
+class TestWriterFactory(py7zr.io.WriterFactory):
+    def __init__(self, target: SevenZipFile):
+        self.target = target
 
-    def __init__(self, httpserver: HTTPServer):
-        self.httpserver: HTTPServer = httpserver
-        self.debug_info = []  # for test
+    def create(self, filename: str) -> py7zr.io.Py7zIO:
+        return TestArchiveWriter(filename, self.target)
 
-    def create(self, filename: str) -> Py7zIO:
-        self.debug_info.append(filename)
-        return StreamWriter(self.httpserver, filename)
+
+@pytest.mark.files
+def test_read_write_new(tmp_path):
+    with py7zr.SevenZipFile(tmp_path.joinpath("target.7z"), "w") as target:
+        with py7zr.SevenZipFile(testdata_path.joinpath("mblock_1.7z").open(mode="rb")) as source:
+            source.readall(TestWriterFactory(target))
+    p7zip_test(tmp_path / "target.7z")
+

--- a/tests/test_stream_nwstorage.py
+++ b/tests/test_stream_nwstorage.py
@@ -21,7 +21,7 @@ def test_extract_stream(httpserver: HTTPServer):
     httpserver.expect_request("/scripts/py7zr", method="PUT").respond_with_data("ok")
     factory = StreamWriterFactory(httpserver)
     with py7zr.SevenZipFile(testdata_path.joinpath("test_1.7z").open(mode="rb")) as archive:
-        archive.readall(factory=factory)
+        archive.extractall(factory=factory)
     assert len(factory.products) == 3
     assert "setup.cfg" in factory.products.keys()
     assert "setup.py" in factory.products.keys()

--- a/tests/test_stream_nwstorage.py
+++ b/tests/test_stream_nwstorage.py
@@ -1,4 +1,3 @@
-import io
 import os
 import pathlib
 from typing import Optional
@@ -9,15 +8,15 @@ from pytest_httpserver import HTTPServer
 import py7zr
 import py7zr.io
 
-from py7zr import Py7zIO
-
 testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
 os.umask(0o022)
 
 
 def test_extract_stream(httpserver: HTTPServer):
     httpserver.expect_request("/setup.cfg", method="PUT").respond_with_data("ok")
-    httpserver.expect_request("/setup.cfg", method="GET").respond_with_data(b"[flake8]\nmax-line-length = 125\n\n[bdist_wheel]\nuniversal=1\n")
+    httpserver.expect_request("/setup.cfg", method="GET").respond_with_data(
+        b"[flake8]\nmax-line-length = 125\n\n[bdist_wheel]\nuniversal=1\n"
+    )
     httpserver.expect_request("/setup.py", method="PUT").respond_with_data("ok")
     httpserver.expect_request("/scripts/py7zr", method="PUT").respond_with_data("ok")
     factory = StreamWriterFactory(httpserver)
@@ -64,7 +63,7 @@ class StreamWriterFactory(py7zr.io.WriterFactory):
         self.httpserver: HTTPServer = httpserver
         self.products = {}
 
-    def create(self, filename: str) -> Py7zIO:
+    def create(self, filename: str) -> py7zr.io.Py7zIO:
         product = StreamWriter(self.httpserver, filename)
         self.products[filename] = product
         return product

--- a/tests/test_stream_nwstorage.py
+++ b/tests/test_stream_nwstorage.py
@@ -1,0 +1,70 @@
+import io
+import os
+import pathlib
+from typing import Optional
+
+import requests
+from pytest_httpserver import HTTPServer
+
+import py7zr
+import py7zr.io
+
+from py7zr import Py7zIO
+
+testdata_path = pathlib.Path(os.path.dirname(__file__)).joinpath("data")
+os.umask(0o022)
+
+
+def test_extract_stream(httpserver: HTTPServer):
+    httpserver.expect_request("/setup.cfg", method="PUT").respond_with_data("ok")
+    httpserver.expect_request("/setup.cfg", method="GET").respond_with_data(b"[flake8]\nmax-line-length = 125\n\n[bdist_wheel]\nuniversal=1\n")
+    httpserver.expect_request("/setup.py", method="PUT").respond_with_data("ok")
+    httpserver.expect_request("/scripts/py7zr", method="PUT").respond_with_data("ok")
+    factory = StreamWriterFactory(httpserver)
+    with py7zr.SevenZipFile(testdata_path.joinpath("test_1.7z").open(mode="rb")) as archive:
+        archive.readall(factory=factory)
+    assert len(factory.products) == 3
+    assert "setup.cfg" in factory.products.keys()
+    assert "setup.py" in factory.products.keys()
+    assert "scripts/py7zr" in factory.products.keys()
+    assert factory.products["setup.cfg"].read() == b"[flake8]\nmax-line-length = 125\n\n[bdist_wheel]\nuniversal=1\n"
+
+
+class StreamWriter(py7zr.io.Py7zIO):
+    """Pseudo object storage writer."""
+
+    def __init__(self, httpserver: HTTPServer, fname: str):
+        self.httpserver: HTTPServer = httpserver
+        self.fname = fname
+        self.length = 0
+
+    def write(self, data: [bytes, bytearray]):
+        self.length += len(data)
+        requests.put(self.httpserver.url_for(self.fname), data=data)
+        self.httpserver.check_assertions()
+
+    def read(self, size: Optional[int] = None) -> bytes:
+        response = requests.get(self.httpserver.url_for(self.fname))
+        return response.content
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        return offset
+
+    def flush(self) -> None:
+        pass
+
+    def size(self) -> int:
+        return self.length
+
+
+class StreamWriterFactory(py7zr.io.WriterFactory):
+    """Factory class to return StreamWriter object."""
+
+    def __init__(self, httpserver: HTTPServer):
+        self.httpserver: HTTPServer = httpserver
+        self.products = {}
+
+    def create(self, filename: str) -> Py7zIO:
+        product = StreamWriter(self.httpserver, filename)
+        self.products[filename] = product
+        return product

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -15,6 +15,7 @@ import pytest
 import py7zr.archiveinfo
 import py7zr.compressor
 import py7zr.helpers
+import py7zr.io
 import py7zr.properties
 from py7zr.py7zr import FILE_ATTRIBUTE_UNIX_EXTENSION
 
@@ -739,7 +740,7 @@ def test_lzmadecompressor_lzmabcj():
 
 @pytest.mark.unit
 def test_unit_buffer():
-    buf = py7zr.helpers.Buffer(size=16)
+    buf = py7zr.io.Buffer(size=16)
     buf.add(b"12345")
     assert len(buf) == 5
     assert buf.get() == bytearray(b"12345")


### PR DESCRIPTION
## Pull request type
 
select from below

- Feature enhancement

## Which ticket is resolved?

## What does this PR change?
    
- refactor: introduce py7zr.io.py
- fix: Drop The read/readall methods
- feat: Extend extract/extactall accept factory callback WriterFactory
- feat: WriterFactory should create Py7zIO object and handle extracted content by user own.

## Other information

User go wrong with the name "read" and "readall" which they belive it should return stream like zipfile. It is why I remove wrong method names.

Reference #575  and  #579

