### PR TITLE
replace inaccessible mirror (qt.mirrors.tds.net) in test

### DIFF
--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -33,7 +33,7 @@ archives = [
     ),
     (
         "qtbase.7z",
-        "http://qt.mirrors.tds.net/qt/online/qtsdkrepository/"
+        "https://download.qt.io/online/qtsdkrepository/"
         "windows_x86/desktop/qt5_5132/qt.qt5.5132.win32_mingw73/"
         "5.13.2-0-201910281254qtbase-Windows-Windows_7-Mingw73-Windows-Windows_7-X86.7z",
     ),


### PR DESCRIPTION
## Pull request type
- Bug fix

## Which ticket is resolved?
- none, I stumbled upon this when packaging py7zr for NixOS in NixOS/nixpkgs#384329

## What does this PR change?
- fixes a test URL that is no longer accessible