### PR TITLE
Update publish-to-pypi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,14 +14,14 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
-      - name: Set up Python 3.9🐍
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.13🐍
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.13
       - name: Install dependency
         run: python -m pip install -U pip wheel setuptools setuptools_scm[toml] twine build
       - name: Build release assets

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build Python 🐍 distributions 📦
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4


### PR DESCRIPTION
## Pull request type
 
- Other

## What does this PR change?

* Bumped `actions/setup-python` to `v5`
* Bumped Python version to `3.13`