### PR TITLE
Update CI configuration for new Python version and dependencies

### DIFF
--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -50,12 +50,12 @@ jobs:
         if: runner.os == 'Windows'
         uses: carlosperate/download-file-action@v2
         with:
-          file-url: "https://libarchive.org/downloads/libarchive-v3.5.3-win64.zip"
-          file-name: "libarchive-v3.5.3-win64.zip"
+          file-url: "https://libarchive.org/downloads/libarchive-3.7.9.zip"
+          file-name: "libarchive-3.7.9.zip"
       - name: Install libarchive(Windows)
         if: runner.os == 'Windows'
         run: |
-          $file = "libarchive-v3.5.3-win64.zip"
+          $file = "libarchive-3.7.9.zip"
           Expand-Archive -LiteralPath $file -DestinationPath $env:GITHUB_WORKSPACE
           choco install graphviz
       - name: Install dependencies
@@ -136,7 +136,7 @@ jobs:
         with:
           fetch-depth: 20
       - name: Build & run test
-        uses: uraimo/run-on-arch-action@v2
+        uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.arch }}
           distro: ${{ matrix.distro }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,12 @@ strategy:
     Python311:
       python.version: '3.11'
       TOXENV: py311
+    Python312:
+      python.version: '3.12'
+      TOXENV: py312
+    Python313:
+      python.version: '3.13'
+      TOXENV: py313
 
 steps:
 - task: UsePythonVersion@0


### PR DESCRIPTION
## Pull request type
- Other

## What does this PR change?
- `run-tox-tests` workflow
Bumped `libarchive` to latest (`v3.7.9`) for Windows
Bumped `uraimo/run-on-arch-action` to `v3`

- `azure-pipelines` workflow
Added Python 3.12 & Python 3.13