### PR TITLE
chore(ci): Restrict Java setup and coverage report to master pushes

### DIFF
--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -87,12 +87,12 @@ jobs:
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: py-${{ matrix.python-version }}-${{ matrix.os }}
       - uses: actions/setup-java@v4
-        if: runner.os != 'Windows'
+        if: ( runner.os != 'Windows' ) && ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' )
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: Send coverage to codacy
-        if: runner.os != 'Windows'
+        if: ( runner.os != 'Windows' ) && ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' )
         run: |
           java -jar utils/codacy-coverage-reporter.jar report -l Python -t ${PROJECT_TOKEN} --partial -r cobertura.xml
         env:

--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -173,10 +173,12 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-java@v4
+        if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' )
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: Send coverage to codacy
+        if: ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' )
         run: |
           java -jar utils/codacy-coverage-reporter.jar final -t ${PROJECT_TOKEN}
         env:


### PR DESCRIPTION
Added conditions to ensure Java setup and coverage reporting only occur for 'push' events on the 'master' branch. This prevents unnecessary executions on other events or branches, optimizing workflow performance.

## Pull request type
 
- Build and release changes

## Which ticket is resolved?

- #643 

## What does this PR change?
- if condition for codacy send configuration on CI
-
-

## Other information
