### PR TITLE
chore: publish workflow as trusted publisher

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -49,9 +49,9 @@ jobs:
           path: dist/
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ startsWith(github.event.ref, 'refs/heads/releases') }}
-        uses: pypa/gh-action-pypi-publish@76f52bc  # release/v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # release/v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@76f52bc # release/v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1.12.4

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,9 +12,9 @@ on:
       - v*
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-20.04
+  build:
+    name: Build Python 🐍 distributions 📦
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
@@ -29,14 +29,29 @@ jobs:
           python -m build --sdist --wheel
       - name: twine check
         run: python -m twine check dist/*
-      - name: Publish distribution 📦 to Test PyPI
-        if: startsWith(github.event.ref, 'refs/heads/releases/')
-        uses: pypa/gh-action-pypi-publish@master
+      - name: upload dist artifacts
+        uses: actions/upload-artifact@v4
         with:
-          password: ${{ secrets.testpypi_password }}
-          repository_url: https://test.pypi.org/legacy/
+          name: dists
+          path: dist/
+
+  pypi-publish:
+    name: publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dists
+          path: dist/
+      - name: Publish distribution 📦 to Test PyPI
+        if: ${{ startsWith(github.event.ref, 'refs/heads/releases') }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.pypi_password }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -49,9 +49,9 @@ jobs:
           path: dist/
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ startsWith(github.event.ref, 'refs/heads/releases') }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc  # release/v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc # release/v1.12.4


### PR DESCRIPTION

## Pull request type
 
- Build and release changes

## Which ticket is resolved?

## What does this PR change?
- Refactor publish workflow into separate distinct "build" and "pypi-publish" jobs to improve security.
- Updated dependencies, permissions, and actions to align with trusted publisher configuration described in https://docs.pypi.org/trusted-publishers/using-a-publisher/

## Other information
