### PR TITLE
fix: `mode="x"` not flushing files in `close()`

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -1149,10 +1149,6 @@ class SevenZipFile(contextlib.AbstractContextManager):
         """Flush all the data into archive and close it.
         When close py7zr start reading target and writing actual archive file.
         """
-        if "w" in self.mode:
-            self._write_flush()
-        if "a" in self.mode:
-            self._write_flush()
         if "r" in self.mode:
             if self.reporterd is not None:
                 self.q.put_nowait(None)
@@ -1160,6 +1156,9 @@ class SevenZipFile(contextlib.AbstractContextManager):
                 if self.reporterd.is_alive():
                     raise InternalError("Progress report thread terminate error.")
                 self.reporterd = None
+        else:  # "w" | "x" | "a" in self.mode
+            self._write_flush()
+
         self._fpclose()
         self._var_release()
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -36,7 +36,8 @@ def test_basic_exclusive_mode(tmp_path):
         archive.write(test1txt, "test1.txt")
 
     with py7zr.SevenZipFile(archivefile) as archive:
-        factory = py7zr.io.BytesIOFactory(limit=test1txt.read_bytes().__sizeof__())
+        limit = len(test1txt.read_bytes())
+        factory = py7zr.io.BytesIOFactory(limit=limit)
         archive.extract(targets=["test1.txt"], factory=factory)
         assert factory.products["test1.txt"].read() == test1txt.read_bytes()
 


### PR DESCRIPTION
## Pull request type

- Bug fix

## Which ticket is resolved?

- Closes https://github.com/miurahr/py7zr/issues/647

## What does this PR change?
- mode `x` now flushes writes.
- Extended the test
