### PR TITLE
Refactor: modularize _make_file_info method

### DIFF
--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -151,7 +151,7 @@ jobs:
             . /root/venv/bin/activate
             git config --global --add safe.directory ${GITHUB_WORKSPACE}
             python3 -c "import platform;print('Machine type:', platform.machine())"
-            python3 -m tox -e py310
+            python3 -m tox -e py312
             coveralls
           env: |
             PYTEST_ADDOPTS: "--cov-config=pyproject.toml --cov --cov-append --benchmark-skip"

--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -143,7 +143,7 @@ jobs:
           githubToken: ${{ github.token }}
           install: |
             apt-get update -q -y
-            apt-get install -q -y p7zip-full python3 python3-pip python3-cffi build-essential gcc git libffi-dev python3-dev libarchive-dev
+            apt-get install -q -y p7zip-full python3-venv build-essential gcc git libffi-dev python3-dev libarchive-dev
             python3 -m venv /root/venv
             . /root/venv/bin/activate
             python3 -m pip install -U pip tox setuptools setuptools_scm[toml] coverage[toml] coveralls

--- a/py7zr/cli.py
+++ b/py7zr/cli.py
@@ -31,7 +31,7 @@ import sys
 from lzma import CHECK_CRC64, CHECK_SHA256, is_check_supported
 from typing import Any, Optional
 
-import _lzma  # type: ignore
+import _lzma
 import multivolumefile
 import texttable  # type: ignore
 

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -73,7 +73,24 @@ if sys.platform.startswith("win"):
 
 FILE_ATTRIBUTE_UNIX_EXTENSION = 0x8000
 FILE_ATTRIBUTE_WINDOWS_MASK = 0x07FFF
-
+# for win32 attributes
+FILE_ATTRIBUTE_ARCHIVE = 32
+FILE_ATTRIBUTE_COMPRESSED = 2048
+FILE_ATTRIBUTE_DEVICE = 64
+FILE_ATTRIBUTE_DIRECTORY = 16
+FILE_ATTRIBUTE_ENCRYPTED = 16384
+FILE_ATTRIBUTE_HIDDEN = 2
+FILE_ATTRIBUTE_INTEGRITY_STREAM = 32768
+FILE_ATTRIBUTE_NORMAL = 128
+FILE_ATTRIBUTE_NOT_CONTENT_INDEXED = 8192
+FILE_ATTRIBUTE_NO_SCRUB_DATA = 131072
+FILE_ATTRIBUTE_OFFLINE = 4096
+FILE_ATTRIBUTE_READONLY = 1
+FILE_ATTRIBUTE_REPARSE_POINT = 1024
+FILE_ATTRIBUTE_SPARSE_FILE = 512
+FILE_ATTRIBUTE_SYSTEM = 4
+FILE_ATTRIBUTE_TEMPORARY = 256
+FILE_ATTRIBUTE_VIRTUAL = 65536
 
 class ArchiveFile:
     """Represent each files metadata inside archive file.
@@ -356,7 +373,7 @@ class SevenZipFile(contextlib.AbstractContextManager):
         if isinstance(file, str):
             # No, it's a filename
             self._filePassed = False
-            self.filename = file
+            self.filename: Optional[str] = file
             modeDict = {
                 "r": "rb",
                 "w": "w+b",
@@ -824,32 +841,37 @@ class SevenZipFile(contextlib.AbstractContextManager):
         else:
             f["filename"] = target.as_posix()
         fstat = target.lstat()
-        if target.is_symlink():
+        if target.is_symlink() and sys.platform == "win32":
             if dereference:
                 fstat = target.stat()
                 if stat.S_ISDIR(fstat.st_mode):
                     f["emptystream"] = True
-                    f["attributes"] = fstat.st_file_attributes & FILE_ATTRIBUTE_WINDOWS_MASK  # noqa
+                    f["attributes"] = self._get_win32_file_attribute(fstat)
                 else:
                     f["emptystream"] = False
-                    f["attributes"] = stat.FILE_ATTRIBUTE_ARCHIVE  # noqa
+                    f["attributes"] = FILE_ATTRIBUTE_ARCHIVE  # noqa
                     f["uncompressed"] = fstat.st_size
             else:
                 f["emptystream"] = False
-                f["attributes"] = fstat.st_file_attributes & FILE_ATTRIBUTE_WINDOWS_MASK  # noqa
+                f["attributes"] = self._get_win32_file_attribute(fstat)
                 # TODO: handle junctions
                 # f['attributes'] |= stat.FILE_ATTRIBUTE_REPARSE_POINT  # noqa
         elif target.is_dir():
             f["emptystream"] = True
-            f["attributes"] = fstat.st_file_attributes & FILE_ATTRIBUTE_WINDOWS_MASK  # noqa
+            f["attributes"] = self._get_win32_file_attribute(fstat)
         elif target.is_file():
             f["emptystream"] = False
-            f["attributes"] = stat.FILE_ATTRIBUTE_ARCHIVE  # noqa
+            f["attributes"] = FILE_ATTRIBUTE_ARCHIVE  # noqa
             f["uncompressed"] = fstat.st_size
         f["creationtime"] = ArchiveTimestamp.from_datetime(fstat.st_ctime)
         f["lastwritetime"] = ArchiveTimestamp.from_datetime(fstat.st_mtime)
         f["lastaccesstime"] = ArchiveTimestamp.from_datetime(fstat.st_atime)
         return f
+
+    def _get_win32_file_attribute(self, fstat: os.stat_result) -> int:
+        if sys.platform == "win32" and hasattr(fstat, "st_file_attributes"):
+            return fstat.st_file_attributes & FILE_ATTRIBUTE_WINDOWS_MASK
+        return 0
 
     def _make_unix_file_info(self, target: pathlib.Path, arcname: Optional[str] = None, dereference=False) -> dict[str, Any]:
         f: dict[str, Any] = {}
@@ -903,11 +925,11 @@ class SevenZipFile(contextlib.AbstractContextManager):
         fstat = target.lstat()
         if target.is_dir():
             f["emptystream"] = True
-            f["attributes"] = stat.FILE_ATTRIBUTE_DIRECTORY
+            f["attributes"] = FILE_ATTRIBUTE_DIRECTORY
         elif target.is_file():
             f["emptystream"] = False
             f["uncompressed"] = fstat.st_size
-            f["attributes"] = stat.FILE_ATTRIBUTE_ARCHIVE
+            f["attributes"] = FILE_ATTRIBUTE_ARCHIVE
         f["creationtime"] = ArchiveTimestamp.from_datetime(fstat.st_ctime)
         f["lastwritetime"] = ArchiveTimestamp.from_datetime(fstat.st_mtime)
         f["lastaccesstime"] = ArchiveTimestamp.from_datetime(fstat.st_atime)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -544,9 +544,8 @@ def test_write_signature_header():
 
 @pytest.mark.unit
 def test_make_file_info1():
-    file_info = py7zr.py7zr.SevenZipFile._make_file_info(
-        pathlib.Path(os.path.join(testdata_path, "src", "bra.txt")), "src/bra.txt"
-    )
+    sevenZipFile = py7zr.SevenZipFile(os.path.join(testdata_path, "test_1.7z"), "r")
+    file_info = sevenZipFile._make_file_info(pathlib.Path(os.path.join(testdata_path, "src", "bra.txt")), "src/bra.txt")
     assert file_info.get("filename") == "src/bra.txt"
     assert not file_info.get("emptystream")
     assert file_info.get("uncompressed") == 11
@@ -554,7 +553,8 @@ def test_make_file_info1():
 
 @pytest.mark.unit
 def test_make_file_info2():
-    file_info = py7zr.py7zr.SevenZipFile._make_file_info(pathlib.Path(testdata_path).joinpath("src"))
+    sevenZipFile = py7zr.SevenZipFile(os.path.join(testdata_path, "test_1.7z"), "r")
+    file_info = sevenZipFile._make_file_info(pathlib.Path(testdata_path).joinpath("src"))
     assert file_info.get("filename") == pathlib.Path(testdata_path).joinpath("src").as_posix()
     assert file_info.get("emptystream")
     flag = stat.FILE_ATTRIBUTE_DIRECTORY


### PR DESCRIPTION
## Pull request type
 
select from below

- refactor

## Which ticket is resolved?

## What does this PR change?

- Refactored _make_file_info function: Split into platform-specific methods: _make_win32_file_info, _make_unix_file_info, and _make_generic_file_info.
- New utility methods: Added methods to handle file attributes and timestamps for better modularity.
- Platform logic in _make_file_info: Platform detection now dispatches calls to appropriate platform-specific methods.
- Test updates: Refactored test cases to instantiate SevenZipFile before using _make_file_info for validation.

## Other information
