### PR TITLE
feat(cli): add support for extracting specific archive members

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -125,9 +125,11 @@ Command-line options
 
    List files in a 7z file.
 
-.. option:: x <7z file> [<output_dir>]
+.. option:: x <7z file> [<output_dir>] [--files <file1> ... <fileN>]
 
-   Extract 7z file into target directory.
+   Extract 7z file into target directory. If ``output_dir`` is specified,
+   py7zr will extract files into the specified directory.
+   Use ``--files`` to extract only the specified archive members. 
 
 .. option:: c <7z file> <base_dir>
 

--- a/py7zr/cli.py
+++ b/py7zr/cli.py
@@ -116,6 +116,7 @@ class Cli:
         extract_parser.set_defaults(func=self.run_extract)
         extract_parser.add_argument("arcfile", type=pathlib.Path, help="7z archive file")
         extract_parser.add_argument("odir", nargs="?", help="output directory")
+        extract_parser.add_argument('--files', nargs='+', help="List of archive members to extract")
         extract_parser.add_argument(
             "-P",
             "--password",
@@ -355,10 +356,16 @@ class Cli:
             archive_info = a.archiveinfo()
             cb = CliExtractCallback(total_bytes=archive_info.uncompressed, ofd=sys.stderr)
         try:
-            if args.odir:
-                a.extractall(path=args.odir, callback=cb)
+            if args.files:
+                a.extract(
+                    path=args.odir,
+                    callback=cb,
+                    targets=args.files,
+                    # Allow to provide directories and extract all files in them.
+                    recursive=True,
+                )
             else:
-                a.extractall(callback=cb)
+                a.extractall(path=args.odir, callback=cb)
         except py7zr.exceptions.UnsupportedCompressionMethodError:
             print("Unsupported compression method is used in archive. ABORT.")
             return 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -281,6 +281,20 @@ def test_cli_extract(tmp_path):
     ]
     check_output(expected, tmp_path)
 
+@pytest.mark.cli
+def test_cli_extract_member(tmp_path):
+    arcfile = os.path.join(testdata_path, "test_1.7z")
+    cli = py7zr.cli.Cli()
+    cli.run(["x", arcfile, str(tmp_path.resolve()), "--files", "setup.cfg"])
+    expected = [
+        {
+            "filename": "setup.cfg",
+            "mode": 33188,
+            "mtime": 1552522033,
+            "digest": "ff77878e070c4ba52732b0c847b5a055a7c454731939c3217db4a7fb4a1e7240",
+        },
+    ]
+    check_output(expected, tmp_path)
 
 @pytest.mark.cli
 def test_cli_encrypted_extract(monkeypatch, tmp_path):


### PR DESCRIPTION
## Feature enhancement

## Which ticket is resolved?

- issue #669.

## What does this PR change?

- This PR adds a new `--files` CLI argument for `py7zr x` to extract individual files.

## Other information
n/a