### PR TITLE
Update docs on deflate64 dependency

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -41,7 +41,7 @@ Package               Purpose
 `PyPPMd`_             PPMd compression
 `Brotli`_             Brotli compression (CPython)
 `BrotliCFFI`_         Brotli compression (PyPy)
-`zipfile-deflate64`_  DEFLATE64 decompression
+`inflate64`_          Enhanced deflate compression
 `pybcj`_              BCJ filters
 `multivolumefile`_    Multi-volume archive read/write
 `texttable`_          CLI formatter


### PR DESCRIPTION
The main readme already mentions inflate64, but the docs still refer to zipfile-deflate64 which I think is outdated and not available for current Python versions.

## Pull request type

- Documentation

## Which ticket is resolved?

- no known issue

## What does this PR change?

- Replace mention of zipfile-deflate64 with inflate64 in docs (same as readme)

## Other information
