### PR TITLE
fix: SevenZipFile.getinfo() now returns FileInfo as originally intended

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -961,11 +961,15 @@ class SevenZipFile(contextlib.AbstractContextManager):
         Calling :meth:`getinfo()` for a name not currently contained in the archive will raise a :exc:`KeyError`."""
         # For interoperability with ZipFile
         name = remove_trailing_slash(name)
-        sevenzipinfo = next((member for member in self.list() if member.filename == name), None)
-        # ZipFile and TarFile raise KeyError if the named member is not found
-        # So for consistency, we'll also raise KeyError here
-        if sevenzipinfo is None:
-            raise KeyError(f"'{name}' not found in archive.")
+
+        try:
+            sevenzipinfo = next(
+                member for member in self.list() if member.filename == name
+            )
+        except StopIteration:
+            # ZipFile and TarFile raise KeyError if the named member is not found
+            # So for consistency, we'll also raise KeyError here
+            raise KeyError(f"'{name}' not found in archive.") from None
 
         return sevenzipinfo
 

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -957,14 +957,11 @@ class SevenZipFile(contextlib.AbstractContextManager):
         return list(map(lambda x: x.filename, self.files))
 
     def getinfo(self, name: str) -> FileInfo:
-        """Return a FileInfo object with information about the archive member *name*.
-        Calling getinfo() for a name not currently contained in the archive will raise a KeyError."""
+        """Return a :class:`FileInfo` object with information about the archive member *name*.
+        Calling :meth:`getinfo()` for a name not currently contained in the archive will raise a :exc:`KeyError`."""
         # For interoperability with ZipFile
         name = remove_trailing_slash(name)
-
-        # https://more-itertools.readthedocs.io/en/stable/_modules/more_itertools/recipes.html#first_true
-        sevenzipinfo = next(filter(lambda member: member.filename == name, self.files), None)
-
+        sevenzipinfo = next((member for member in self.list() if member.filename == name), None)
         # ZipFile and TarFile raise KeyError if the named member is not found
         # So for consistency, we'll also raise KeyError here
         if sevenzipinfo is None:

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from py7zr import SevenZipFile
+from py7zr import FileInfo, SevenZipFile
 
 testdata_path = os.path.join(os.path.dirname(__file__), "data")
 
@@ -12,6 +12,7 @@ def test_getinfo_file():
         member = archive.getinfo("test1.txt")
         assert member.filename == "test1.txt"
         assert member.is_directory is False
+        assert isinstance(member, FileInfo)
 
 
 def test_getinfo_dir():
@@ -19,6 +20,7 @@ def test_getinfo_dir():
         member = archive.getinfo("test")
         assert member.filename == "test"
         assert member.is_directory is True
+        assert isinstance(member, FileInfo)
 
 
 def test_getinfo_file_with_trailing_slash():
@@ -26,6 +28,7 @@ def test_getinfo_file_with_trailing_slash():
         member = archive.getinfo("test1.txt/")
         assert member.filename == "test1.txt"
         assert member.is_directory is False
+        assert isinstance(member, FileInfo)
 
 
 def test_getinfo_dir_with_trailing_slash():
@@ -33,6 +36,7 @@ def test_getinfo_dir_with_trailing_slash():
         member = archive.getinfo("test/")
         assert member.filename == "test"
         assert member.is_directory is True
+        assert isinstance(member, FileInfo)
 
 
 def test_getinfo_missing_member():


### PR DESCRIPTION
## Pull request type
- Bug fix

## Which ticket is resolved?
- https://github.com/miurahr/py7zr/issues/675

## What does this PR change?

- `SevenZipFile.getinfo()` now correctly returns `FileInfo` instead of `ArchiveFile`.  
  It now looks up the file in `self.list()` (which returns `list[FileInfo]`) instead of `self.files` (`ArchiveFileList`).

## Other information
While this is technically a backwards-incompatible change, it should be practically compatible because:
  - The documentation explicitly states that the return type is `FileInfo`.
  - `ArchiveFile` and `FileInfo` have overlapping interfaces.
  - `FileInfo` is the return type hint, so type checkers would enforce that only `FileInfo` attributes are accessed.
