### PR TITLE
chore: bump minimum Python version to 3.10 and update development deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py7zr"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "Pure python 7-zip library"
 license = {text = "LGPL-2.1-or-later"}
 authors = [
@@ -61,20 +61,20 @@ test = [
       "pytest-remotedata",
       "pytest-timeout",
       "py-cpuinfo",
-      "coverage[toml]>=5.2",
-      "coveralls>=2.1.1",
+      "coverage[toml]>=7.10.7",
+      "coveralls>=4.0.2",
       "requests",
       "pytest-httpserver",
 ]
 docs = [
-      "sphinx>=7.0.0",
+      "sphinx>=8.0.0",
       "sphinx-py3doc-enhanced-theme",
       "sphinx-a4doc",
       "docutils",
 ]
 check = [
-      "mypy>=1.10.0",
-      "mypy_extensions>=1.0.0",
+      "mypy>=1.17.0",
+      "mypy_extensions>=1.1.0",
       "lxml",
       "types-psutil",
       "check-manifest",
@@ -82,11 +82,11 @@ check = [
       "flake8-black>=0.3.6",
       "flake8-deprecated",
       "flake8-isort",
-      "isort>=5.13.2",
+      "isort>=7.0.0",
       "pygments",
       "readme-renderer",
       "twine",
-      "black>=24.8.0",
+      "black>=25.1.0",
       "pylint",
 ]
 debug = [
@@ -103,7 +103,7 @@ Source = "https://github.com/miurahr/py7zr"
 Changelog = "https://py7zr.readthedocs.io/en/latest/Changelog.html"
 
 [build-system]
-requires = ["setuptools>=63", "build", "setuptools_scm[toml]>=7.0.5"]
+requires = ["setuptools>=80", "build", "setuptools_scm[toml]>=9.2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
@@ -214,7 +214,7 @@ commands =
     twine check dist/*
 
 [testenv:clean]
-deps = coverage[toml]>=5.2
+deps = coverage[toml]>=7.10.7
 skip_install = true
 commands = coverage erase
 


### PR DESCRIPTION
## Pull request type
 
- dependencies

## What does this PR change?


- coverage@7.10.7
- coveralls@4.0.2
- sphinx@8.0.0
- mypy@1.17.0
- black@25.1.0
