### PR TITLE
Update build dependencies and drop 3.9 and pypy 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,13 @@
 name = "py7zr"
 requires-python = ">=3.10"
 description = "Pure python 7-zip library"
-license = {text = "LGPL-2.1-or-later"}
+readme = "README.rst"
+license = "LGPL-2.1-or-later"
 authors = [
     {name = "Hiroshi Miura", email = "miurahr@linux.com"},
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
@@ -38,16 +38,13 @@ dependencies = [
       "inflate64>=1.0.4",
 ]
 keywords = ['compression', '7zip', 'lzma', 'zstandard', 'ppmd', 'lzma2', 'bcj', 'archive']
-dynamic = ["readme", "version"]
+dynamic = ["version"]
 
 [tool.setuptools]
 packages = ["py7zr"]
 
 [tool.setuptools.package-data]
 py7zr = ["py.typed"]
-
-[tool.setuptools.dynamic]
-readme = {file = ["README.rst"]}
 
 [project.scripts]
 py7zr = "py7zr.__main__:main"
@@ -103,13 +100,13 @@ Source = "https://github.com/miurahr/py7zr"
 Changelog = "https://py7zr.readthedocs.io/en/latest/Changelog.html"
 
 [build-system]
-requires = ["setuptools>=80", "build", "setuptools_scm[toml]>=9.2.0"]
+requires = ["setuptools>=80", "setuptools_scm[toml]>=9.2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
-write_to = "py7zr/version.py"
-write_to_template = """
+version_file = "py7zr/version.py"
+version_file_template = """
 __version__ = \"{version}\"
 """
 tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
@@ -125,7 +122,7 @@ exclude_lines = ["if __name__ == .__main__.:", "pragma: no-cover", "@abstract", 
 
 [tool.black]
 line-length = 125
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.isort]
 known_first_party = ['py7zr']
@@ -170,7 +167,7 @@ markers = [
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = mypy, check, pypy310, py{310,311,312,313,314}, docs, mprof, distcheck
+envlist = mypy, check, pypy311, py{310,311,312,313,314}, docs, mprof, distcheck
 
 [testenv]
 passenv =
@@ -182,10 +179,10 @@ extras = test
 commands =
     python -m pytest -vv
 
-[testenv:py39]
+[testenv:py310]
 extras = test, test_compat
 
-[testenv:pypy39]
+[testenv:pypy311]
 extras = test, test_compat
 
 [testenv:mprof]
@@ -238,5 +235,5 @@ python =
     3.12: py312
     3.13: py313
     3.14: py314
-    pypy-3.10: pypy310
+    pypy-3.11: pypy311
 """


### PR DESCRIPTION
## Pull request type
- Feature enhancement
## Which ticket is resolved?
N/A
## What does this PR change?
- Update build dependencies to get newer features (such as [support for PEP 639 License expressions](https://setuptools.pypa.io/en/stable/history.html#v77-0-0))
- Remove cpython 3.9 and pypy 3.10 from tox. [PyPy 3.10 is now EoL.](https://pypy.org/posts/2025/07/pypy-v7320-release.html)
