### PR TITLE
Update `codeql-analysis` workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Pull request type

- Other (workflow refactor)

## Which ticket is resolved?

- N/A

## What does this PR change?

- Bump `actions/checkout` to `v6`.
- Bump `codeql-action/init` to `v4`.
- Bump `codeql-action/init` to `v4`.

## Other information
CodeQL Action `v3` will be deprecated in December 2026.
Please update all occurrences of the CodeQL Action in your workflow files to `v4`.
For more information, see https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/