### PR TITLE
chore(ci): Bump 3 GitHub `actions` for full Node.js 24 compatibility

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -50,7 +50,7 @@ jobs:
       - name: twine check
         run: python -m twine check dist/*
       - name: upload dist artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: dists
           path: dist/
@@ -64,7 +64,7 @@ jobs:
       id-token: write
     steps:
       - name: download dist artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: dists
           path: dist/

--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -91,7 +91,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: py-${{ matrix.python-version }}-${{ matrix.os }}
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         if: ( runner.os != 'Windows' ) && ( github.event_name == 'push' ) && ( github.ref == 'refs/heads/master' )
         with:
           distribution: 'temurin'


### PR DESCRIPTION
## Pull request type

- Other

## Which ticket is resolved?

- N/A

## What does this PR change?

- Bump 3 GitHub `actions` for full Node.js 24 compatibility.

## Other information
* https://github.com/actions/download-artifact/releases
* https://github.com/actions/upload-artifact/releases
* https://github.com/actions/setup-java/releases