### PR TITLE
refactor:  Revise gha runner(s) used in `run-tox-tests` workflow

### DIFF
--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest, ubuntu-24.04-arm, windows-11-arm]
+        os: [ubuntu-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
         python-version: [
             "3.10",
             "3.11",
@@ -111,7 +111,7 @@ jobs:
 
   test_slow_tests:
     name: Test slow cases
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Pull request type
 
- Other

## Which ticket is resolved?

N/A

## What does this PR change?

* Replaces the `ubuntu-22.04 & ubuntu-24.04` runner images with `ubuntu-latest` in `run-tox-tests` workflow.

## Other information
