### PR TITLE
Fix performance issue in write_utf16 caused by per-character encoding

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -217,8 +217,7 @@ def read_utf16(file: BinaryIO) -> str:
 
 def write_utf16(file: BinaryIO | WriteWithCrc, val: str):
     """write a utf-16 string to file"""
-    for c in val:
-        file.write(c.encode("utf-16LE"))
+    file.write(val.encode("utf-16LE"))
     file.write(b"\x00\x00")
 
 


### PR DESCRIPTION
## Pull request type
 
- Bug fix

## Which ticket is resolved?

- no ticket

## What does this PR change?

This PR fixes an inefficient implementation in write_utf16 where the encoder
was called once per character instead of once per string.

Encoding the entire string in a single call reduces overhead and improves
performance, particularly when processing archives with many filenames.

## Other information

### Background

I encountered this issue while working with 7z archives containing a very
large number of files. Due to intentionally controlling folder structures,
I was frequently opening archives in append ("a") mode.

I noticed that SevenZipFile.close() was taking a considerable amount of
time, which led me to trace the header writing process and eventually
identify this bottleneck in write_utf16.

### Proof of Concept (PoC)

The following code demonstrates the performance impact when an archive contains
100,000 files with paths of approximately 30 characters:

<details>
<summary>PoC code</summary>

```python:poc.py
import time
from tempfile import TemporaryDirectory
from py7zr import SevenZipFile

def setup(zip_path):
    with SevenZipFile(zip_path, "w") as zip:
        for i in range(100_000):
           zip.writestr(b"", f"file_{i}_"+("a"*20))

def perform(zip_path):
    zip = SevenZipFile(zip_path, "a")
    t_start = time.perf_counter()
    zip.close()
    t_end = time.perf_counter()
    print(f"elapsed: {t_end-t_start:f} s")

def apply_patch():
    import py7zr.archiveinfo
    def write_utf16(file, val: str):
        file.write(val.encode("utf-16LE"))
        file.write(b"\x00\x00")
    py7zr.archiveinfo.write_utf16 = write_utf16

if __name__ == "__main__":
    with TemporaryDirectory() as tmpdir:
        zip_path = f"{tmpdir}/test.7z"
        setup(zip_path)
        perform(zip_path)
        apply_patch()
        perform(zip_path)
```

```
$ python3 poc.py
elapsed: 5.512148 s
elapsed: 3.594147 s
```
</details>