### PR TITLE
Improve read_utf16 performance by avoiding per-character string concatenation

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -26,7 +26,6 @@ import io
 import operator
 import os
 import struct
-from binascii import unhexlify
 from functools import reduce
 from io import BytesIO
 from operator import and_, or_
@@ -177,7 +176,7 @@ def write_uint64(file: BinaryIO | WriteWithCrc, value: int):
 def read_boolean(file: BinaryIO, count: int, checkall: bool = False) -> list[bool]:
     if checkall:
         all_defined = file.read(1)
-        if all_defined != unhexlify("00"):
+        if all_defined != b"\x00":
             return [True] * count
     result = []
     b = 0
@@ -209,7 +208,7 @@ def read_utf16(file: BinaryIO) -> str:
     nul = False
     for i in range(MAX_LENGTH):
         ch = file.read(2)
-        if ch == unhexlify("0000"):
+        if ch == b"\x00\x00":
             nul = True
             break
     size = (i + 1) * 2

--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -206,12 +206,17 @@ def write_boolean(file: BinaryIO | WriteWithCrc, booleans: list[bool], all_defin
 
 def read_utf16(file: BinaryIO) -> str:
     """read a utf-16 string from file"""
-    val = b""
-    for _ in range(MAX_LENGTH):
+    nul = False
+    for i in range(MAX_LENGTH):
         ch = file.read(2)
         if ch == unhexlify("0000"):
+            nul = True
             break
-        val += ch
+    size = (i + 1) * 2
+    file.seek(-size, 1)
+    val = file.read(size)
+    if nul:
+        val = val[:-2]
     return val.decode("utf-16LE")
 
 


### PR DESCRIPTION
## Pull request type

 - Other: Performance improvement

## Which ticket is resolved?

- no ticket

## What does this PR change?

This PR improves the performance of read_utf16, which is used when reading
filenames while opening an archive.

Changes:

- Keep reading 1 character (2 bytes) at a time to locate the null terminator,
but remove incremental string concatenation.
- After locating the terminator, read the full range in bulk instead.
- Remove clearly unnecessary uses of unhexlify.

## Other information

### Background

This PR is motivated by the same use case as PR #725. While that PR improves the
performance of close() in w/a modes for archives with many files, this PR
improves the performance of open() in r/a modes during header reading.

### Proof of Concept (PoC)

<details>
<summary>PoC code</summary>

```python:poc.py
import time
from py7zr import SevenZipFile
from py7zr.archiveinfo import MAX_LENGTH

def setup(zip_path):
    with SevenZipFile(zip_path, "w") as zip:
        for i in range(1_000_000):
           zip.writestr(b"", f"file_{i}_"+("a"*20))

def perform(zip_path, note):
    t_start = time.perf_counter()
    zip = SevenZipFile(zip_path, "r")
    t_end = time.perf_counter()
    print(f"elapsed: {t_end-t_start:f} s -- {note}")
    zip.close()

def apply_patch1():
    import py7zr.archiveinfo
    def read_utf16(file) -> str:
        val = b""
        for _ in range(MAX_LENGTH):
            ch = file.read(2)
            # Avoid unnecessary function calls
            #if ch == unhexlify("0000"):
            if ch == b"\x00\x00":
                break
            val += ch
        return val.decode("utf-16LE")
    py7zr.archiveinfo.read_utf16 = read_utf16

def apply_patch2():
    import py7zr.archiveinfo
    def read_utf16(file) -> str:
        # Avoid excessive string concatenation
        nul = False
        for i in range(MAX_LENGTH):
            ch = file.read(2)
            if ch == b"\x00\x00":
                nul = True
                break
        # Re-read all at once instead
        size = (i + 1) * 2
        file.seek(-size, 1)
        val = file.read(size)
        if nul:
            val = val[:-2]
        return val.decode("utf-16LE")
    py7zr.archiveinfo.read_utf16 = read_utf16

if __name__ == "__main__":
    from tempfile import TemporaryDirectory
    with TemporaryDirectory() as tmpdir:
        zip_path = f"{tmpdir}/test.7z"
        setup(zip_path)
        perform(zip_path, note="baseline")
        apply_patch1()
        perform(zip_path, note="remove unhexlify")
        apply_patch2()
        perform(zip_path, note="and re-read in bulk")
```
</details>

```
$ python3 poc2.py
elapsed: 7.418241 s -- baseline
elapsed: 6.909115 s -- remove unhexlify
elapsed: 5.997517 s -- and re-read in bulk
```
