### PR TITLE
Handle missing lastwritetime during extract

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -670,12 +670,9 @@ class SevenZipFile(contextlib.AbstractContextManager):
         # set file properties
         for outfilename, properties in target_files:
             # mtime
-            lastmodified = None
-            try:
-                lastmodified = ArchiveTimestamp(properties["lastwritetime"]).totimestamp()
-            except KeyError:
-                pass
-            if lastmodified is not None:
+            lastwritetime = properties.get("lastwritetime")
+            if lastwritetime is not None:
+                lastmodified = ArchiveTimestamp(lastwritetime).totimestamp()
                 os.utime(str(outfilename), times=(lastmodified, lastmodified))
             if os.name == "posix":
                 st_mode = properties["posix_mode"]

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -74,6 +74,14 @@ def test_solid_mem(tmp_path):
 
 
 @pytest.mark.files
+def test_extract_file_without_lastwritetime(tmp_path):
+    with py7zr.SevenZipFile(testdata_path.joinpath("test_1.7z").open(mode="rb")) as archive:
+        archive.files[1].file_properties()["lastwritetime"] = None
+        archive.extractall(path=tmp_path)
+    assert tmp_path.joinpath("scripts/py7zr").is_file()
+
+
+@pytest.mark.files
 def test_empty():
     # decompress empty archive
     archive = py7zr.SevenZipFile(testdata_path.joinpath("empty.7z").open(mode="rb"))


### PR DESCRIPTION
## Summary
- skip mtime restoration when an archive member has no lastwritetime value
- add a regression test for extracting a member whose lastwritetime is None

Fixes #734.

## Tests
- .venv/bin/python -m pytest tests/test_extract.py::test_extract_file_without_lastwritetime -q
- .venv/bin/python -m pytest tests/test_extract.py -q
- .venv/bin/python -m pytest -q
- .venv/bin/python -m compileall -q py7zr/py7zr.py tests/test_extract.py
