### PR TITLE
fix: correct buffer size calculation by seeking without altering position

### DIFF
--- a/py7zr/io.py
+++ b/py7zr/io.py
@@ -91,7 +91,11 @@ class Py7zBytesIO(Py7zIO):
         return self._buffer.flush()
 
     def size(self) -> int:
-        return self._buffer.getbuffer().nbytes
+        current_pos = self._buffer.tell()
+        self._buffer.seek(0, io.SEEK_END)
+        size = self._buffer.tell()
+        self._buffer.seek(current_pos)
+        return size
 
 
 class WriterFactory(ABC):


### PR DESCRIPTION
## Pull request type
 
select from below

- Bug fix

## Which ticket is resolved?

- issue #736

## What does this PR change?

Avoid using BytesIO.getbuffer() in Py7zBytesIO.size()

## Other information
