### PR TITLE
Require password for crypto write filters

### DIFF
--- a/py7zr/compressor.py
+++ b/py7zr/compressor.py
@@ -822,6 +822,8 @@ class SevenZipCompressor:
         if len(self.filters) > 4:
             raise UnsupportedCompressionMethodError(filters, f"Maximum cascade of filters is 4 but got {len(self.filters)}.")
         self.methods_map = [SupportedMethods.is_native_filter(filter) for filter in self.filters]
+        if password is None and SupportedMethods.needs_password_for_filters(self.filters):
+            raise PasswordRequired(self.filters, "Password is required for writing encrypted archive.")
         self.coders: list[dict[str, Any]] = []
         if all(self.methods_map) and SupportedMethods.is_compressor(self.filters[-1]):  # all native
             self._set_native_compressors_coders(self.filters)
@@ -1170,6 +1172,13 @@ class SupportedMethods:
             if filter_id is None:
                 continue
             if SupportedMethods.is_crypto_id(filter_id):
+                return True
+        return False
+
+    @classmethod
+    def needs_password_for_filters(cls, filters) -> bool:
+        for filter_spec in filters:
+            if SupportedMethods.is_crypto_id(filter_spec["id"]):
                 return True
         return False
 

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -58,6 +58,7 @@ from py7zr.exceptions import (
     DecompressionBombError,
     DecompressionError,
     InternalError,
+    PasswordRequired,
     UnsupportedCompressionMethodError,
 )
 from py7zr.helpers import (
@@ -698,6 +699,8 @@ class SevenZipFile(contextlib.AbstractContextManager):
             for f in filters:
                 if f["id"] == FILTER_DEFLATE64:
                     raise UnsupportedCompressionMethodError(filters, "Compression with deflate64 is not supported.")
+        if password is None and SupportedMethods.needs_password_for_filters(filters):
+            raise PasswordRequired(filters, "Password is required for writing encrypted archive.")
         self.header.filters = filters
         self.header.password = password
         if self.header.main_streams is not None:
@@ -712,6 +715,8 @@ class SevenZipFile(contextlib.AbstractContextManager):
             filters = DEFAULT_FILTERS.ENCRYPTED_ARCHIVE_FILTER
         elif filters is None:
             filters = DEFAULT_FILTERS.ARCHIVE_FILTER
+        if password is None and SupportedMethods.needs_password_for_filters(filters):
+            raise PasswordRequired(filters, "Password is required for writing encrypted archive.")
         self.files = ArchiveFileList()
         self.sig_header = SignatureHeader()
         self.sig_header._write_skeleton(self.fp)

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -92,6 +92,13 @@ def test_extract_encrypted_6(tmp_path):
 
 
 @pytest.mark.files
+def test_encrypt_crypto_filter_requires_password(tmp_path):
+    filters = [{"id": py7zr.FILTER_CRYPTO_AES256_SHA256}]
+    with pytest.raises(PasswordRequired, match="Password is required"):
+        py7zr.SevenZipFile(tmp_path.joinpath("target.7z"), "w", password=None, filters=filters)
+
+
+@pytest.mark.files
 def test_encrypt_file_0(tmp_path):
     filters = [{"id": py7zr.FILTER_LZMA}, {"id": py7zr.FILTER_CRYPTO_AES256_SHA256}]
     tmp_path.joinpath("src").mkdir()


### PR DESCRIPTION
## Pull request type

- Bug fix

## Which ticket is resolved?

- Fixes #723

## What does this PR change?

This raises `PasswordRequired` when write/append mode is configured with a crypto filter such as `FILTER_CRYPTO_AES256_SHA256` but no password is provided. It prevents the lower-level `AttributeError` from `AESCompressor(None)` and also guards direct `SevenZipCompressor` use.

A regression test covers the public `SevenZipFile(..., mode="w", filters=[...], password=None)` path.

## Tests

- `uv run --with '.[test]' pytest tests/test_encryption.py::test_encrypt_crypto_filter_requires_password -q`\n- `uv run --with '.[test]' pytest tests/test_encryption.py -q`\n- `uv run --with '.[test]' pytest tests/test_unit.py -q`\n- `uv run --with '.[test]' pytest -q` -> 367 passed, 9 skipped\n- `uv run --with . python -m compileall -q py7zr`\n- `uv run --with '.[check]' flake8 py7zr/compressor.py tests/test_encryption.py`\n- `uv run --with '.[check]' black --check py7zr/compressor.py py7zr/py7zr.py tests/test_encryption.py`\n- `git diff --check`\n\nFull local `mypy py7zr` and `flake8 py7zr tests` currently report existing unrelated issues on `origin/master` (for example `py7zr/archiveinfo.py:966` and pre-existing formatting/import diagnostics), so I kept this PR scoped to the password validation fix.\n\nAI assistance was used under my direction.