### PR TITLE
Limit parallel extract worker tasks

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -1324,6 +1324,7 @@ class Worker:
                     self.extract_single(open(filename, "rb"), empty_files, path, 0, 0, q)
                     concurrent_tasks = []
                     exc_q: queue.Queue = queue.Queue()
+                    max_workers = max(1, os.cpu_count() or 1)
                     for i in range(numfolders):
                         if skip_notarget:
                             if not any([self.target_filepath.get(f.id, None) for f in folders[i].files]):
@@ -1343,6 +1344,8 @@ class Worker:
                         )
                         p.start()
                         concurrent_tasks.append(p)
+                        if len(concurrent_tasks) >= max_workers:
+                            concurrent_tasks.pop(0).join()
                     for p in concurrent_tasks:
                         p.join()
                     if exc_q.empty():

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -9,6 +9,7 @@ import pathlib
 import stat
 import struct
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -17,7 +18,7 @@ import py7zr.compressor
 import py7zr.helpers
 import py7zr.io
 import py7zr.properties
-from py7zr.py7zr import FILE_ATTRIBUTE_UNIX_EXTENSION
+from py7zr.py7zr import FILE_ATTRIBUTE_UNIX_EXTENSION, Worker
 
 testdata_path = os.path.join(os.path.dirname(__file__), "data")
 
@@ -125,6 +126,45 @@ def test_py7zr_unpack_info():
     unpack_info.write(buffer)
     actual = buffer.getvalue()
     assert actual == b"\x07\x0b\x01\x00\x01#\x03\x01\x01\x05]\x00\x10\x00\x00\x0c\x22\x00"
+
+
+@pytest.mark.unit
+def test_worker_limits_parallel_extract_tasks(monkeypatch, tmp_path):
+    class FakeTask:
+        active = 0
+        max_active = 0
+
+        def __init__(self, target, args):
+            self.target = target
+            self.args = args
+
+        def start(self):
+            type(self).active += 1
+            type(self).max_active = max(type(self).max_active, type(self).active)
+
+        def join(self):
+            type(self).active -= 1
+
+    files = [SimpleNamespace(id=i, emptystream=False) for i in range(5)]
+    folders = [SimpleNamespace(files=[file]) for file in files]
+    header = SimpleNamespace(
+        main_streams=SimpleNamespace(
+            packinfo=SimpleNamespace(packpositions=list(range(len(files) + 1))),
+            unpackinfo=SimpleNamespace(numfolders=len(folders), folders=folders),
+        )
+    )
+    source = tmp_path / "archive.7z"
+    source.write_bytes(b"")
+
+    worker = Worker(files, 0, header)
+    worker.concurrent = FakeTask
+    worker.target_filepath.update((file.id, tmp_path / str(file.id)) for file in files)
+    monkeypatch.setattr(py7zr.py7zr.os, "cpu_count", lambda: 2)
+
+    with source.open("rb") as fp:
+        worker.extract(fp, tmp_path, parallel=True)
+
+    assert FakeTask.max_active == 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes #630.

## Summary
- cap concurrent non-solid extract tasks at `os.cpu_count()` instead of starting one thread/process per folder
- keep the existing `Thread`/`Process` worker implementation and join the oldest task when the cap is reached
- add a unit test with a fake worker class to verify only two tasks run concurrently when `os.cpu_count()` is patched to 2

## Verification
- Red before fix: `uv run --python 3.11 --extra test pytest tests/test_unit.py::test_worker_limits_parallel_extract_tasks -q` failed with `FakeTask.max_active == 5`
- `uv run --python 3.11 --extra test pytest tests/test_unit.py::test_worker_limits_parallel_extract_tasks -q`
- `uv run --python 3.11 --extra test pytest tests/test_concurrent.py::test_concurrent_extraction -q`
- `uv run --python 3.11 --extra test pytest tests/test_unit.py -q`
- `uv run --python 3.11 --extra test pytest -q`
- `uv run --python 3.11 --extra check black --check py7zr/py7zr.py tests/test_unit.py`
- `uv run --python 3.11 --extra check flake8 tests/test_unit.py`
- `git diff --check`

Additional local checks:
- `uv run --python 3.11 --extra check flake8 py7zr/py7zr.py tests/test_unit.py` is blocked by existing `E704` reports in `py7zr/py7zr.py:85-86`.
- `uv run --python 3.11 --extra check mypy py7zr` is blocked by existing `py7zr/archiveinfo.py:966` `bytearray`/`bytes` typing error.

AI assistance was used under my direction.