### PR TITLE
Fix AttributeError in archiveinfo() for archives with no compressed content

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -819,6 +819,8 @@ class SevenZipFile(contextlib.AbstractContextManager):
             return False
 
     def _get_method_names(self) -> list[str]:
+        if self.header.main_streams is None:
+            return []
         try:
             return get_methods_names([folder.coders for folder in self.header.main_streams.unpackinfo.folders])
         except KeyError:
@@ -835,6 +837,8 @@ class SevenZipFile(contextlib.AbstractContextManager):
         return digest
 
     def _is_solid(self):
+        if self.header.main_streams is None:
+            return False
         for f in self.header.main_streams.substreamsinfo.num_unpackstreams_folders:
             if f > 1:
                 return True
@@ -950,7 +954,8 @@ class SevenZipFile(contextlib.AbstractContextManager):
         return sevenzipinfo
 
     def archiveinfo(self) -> ArchiveInfo:
-        total_uncompressed = functools.reduce(lambda x, y: x + y, [f.uncompressed for f in self.files])
+        uncompressed_list = [f.uncompressed for f in self.files]
+        total_uncompressed = functools.reduce(lambda x, y: x + y, uncompressed_list, 0)
         if isinstance(self.fp, multivolumefile.MultiVolume):
             fname = self.fp.name
             fstat = self.fp.stat()
@@ -958,13 +963,14 @@ class SevenZipFile(contextlib.AbstractContextManager):
             fname = self.filename
             assert fname is not None
             fstat = os.stat(fname)
+        blocks = len(self.header.main_streams.unpackinfo.folders) if self.header.main_streams is not None else 0
         return ArchiveInfo(
             fname,
             fstat,
             self.header.size,
             self._get_method_names(),
             self._is_solid(),
-            len(self.header.main_streams.unpackinfo.folders),
+            blocks,
             total_uncompressed,
         )
 

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -839,7 +839,10 @@ class SevenZipFile(contextlib.AbstractContextManager):
     def _is_solid(self):
         if self.header.main_streams is None:
             return False
-        for f in self.header.main_streams.substreamsinfo.num_unpackstreams_folders:
+        substreamsinfo = self.header.main_streams.substreamsinfo
+        if substreamsinfo is None:
+            return False
+        for f in substreamsinfo.num_unpackstreams_folders:
             if f > 1:
                 return True
         return False

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -135,3 +135,14 @@ def test_list_filename_encryption(tmp_path):
     with py7zr.SevenZipFile(os.path.join(testdata_path, "filename_encryption.7z"), "r", password="hello") as ar:
         file_list = ar.list()
         assert file_list[0].filename == "New Text Document.TXT"
+
+
+@pytest.mark.files
+def test_archiveinfo_empty_archive():
+    """archiveinfo() must not crash on an empty archive (main_streams is None)."""
+    with py7zr.SevenZipFile(os.path.join(testdata_path, "empty.7z"), "r") as ar:
+        ai = ar.archiveinfo()
+        assert ai.method_names == []
+        assert ai.solid is False
+        assert ai.blocks == 0
+        assert ai.uncompressed == 0

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -146,3 +147,10 @@ def test_archiveinfo_empty_archive():
         assert ai.solid is False
         assert ai.blocks == 0
         assert ai.uncompressed == 0
+
+
+def test_is_solid_without_substreamsinfo():
+    ar = py7zr.SevenZipFile.__new__(py7zr.SevenZipFile)
+    ar.header = SimpleNamespace(main_streams=SimpleNamespace(substreamsinfo=None))
+
+    assert ar._is_solid() is False


### PR DESCRIPTION
## Problem

`archiveinfo()` crashes with `AttributeError: 'NoneType' object has no attribute 'unpackinfo'` when called on an archive whose `header.main_streams` is `None` — i.e., an archive that contains no compressed content (empty archive or one with only empty-file/directory entries). Reported in #665.

Three places in `SevenZipFile` blindly dereference `self.header.main_streams` without a `None` guard:

- `_get_method_names()` — iterates `main_streams.unpackinfo.folders`
- `_is_solid()` — iterates `main_streams.substreamsinfo.num_unpackstreams_folders`
- `archiveinfo()` — calls `len(main_streams.unpackinfo.folders)` directly; also passes an empty iterable to `functools.reduce()` without an initial value, which raises `TypeError`

## Fix

- Add `if self.header.main_streams is None: return []` guard at the top of `_get_method_names()`.
- Add `if self.header.main_streams is None: return False` guard at the top of `_is_solid()`.
- In `archiveinfo()`, compute `blocks` via a conditional expression; supply `0` as the initial value to `functools.reduce()` so an empty files list returns `0` instead of raising `TypeError`.

## Test

Added `test_archiveinfo_empty_archive` in `tests/test_info.py` that opens the existing `tests/data/empty.7z` fixture and asserts the returned `ArchiveInfo` has `method_names=[]`, `solid=False`, `blocks=0`, and `uncompressed=0`.