### PR TITLE
normalized windows extended path indidcator

### DIFF
--- a/py7zr/helpers.py
+++ b/py7zr/helpers.py
@@ -339,10 +339,10 @@ def clean_windows_extended_length_path_indicator(path: pathlib.Path) -> pathlib.
     if isinstance(path, pathlib.WindowsPath):
         path_str = str(path)
         if path_str.startswith("\\\\?\\UNC\\"):
-            print(f"cleaning windows extended length path indicator from: {path}")
+            #print(f"cleaning windows extended length path indicator from: {path}")
             return pathlib.Path("\\\\" + path_str.removeprefix("\\\\?\\UNC\\"))
         if path_str.startswith("\\\\?\\"):
-            print(f"cleaning windows extended length path indicator from: {path}")
+            #print(f"cleaning windows extended length path indicator from: {path}")
             return pathlib.Path(path_str.removeprefix("\\\\?\\"))
     return path
 

--- a/py7zr/helpers.py
+++ b/py7zr/helpers.py
@@ -336,12 +336,14 @@ def canonical_path(target: pathlib.Path) -> pathlib.Path:
 
 
 def clean_windows_extended_length_path_indicator(path: pathlib.Path) -> pathlib.Path:
-    extended_length_path_re = r"^\\\\\?\\"
     if isinstance(path, pathlib.WindowsPath):
-        clean_path = pathlib.Path(re.sub(extended_length_path_re, "", str(path)))
-        if clean_path != path:
-            print(f"cleaned windows extended length path indicator: {path} -> {clean_path}")
-        return clean_path
+        path_str = str(path)
+        if path_str.startswith("\\\\?\\UNC\\"):
+            print(f"cleaning windows extended length path indicator from: {path}")
+            return pathlib.Path("\\\\" + path_str.removeprefix("\\\\?\\UNC\\"))
+        if path_str.startswith("\\\\?\\"):
+            print(f"cleaning windows extended length path indicator from: {path}")
+            return pathlib.Path(path_str.removeprefix("\\\\?\\"))
     return path
 
 

--- a/py7zr/helpers.py
+++ b/py7zr/helpers.py
@@ -335,6 +335,16 @@ def canonical_path(target: pathlib.Path) -> pathlib.Path:
     return pathlib.Path(*stack)
 
 
+def clean_windows_extended_length_path_indicator(path: pathlib.Path) -> pathlib.Path:
+    extended_length_path_re = r"^\\\\\?\\"
+    if isinstance(path, pathlib.WindowsPath):
+        clean_path = pathlib.Path(re.sub(extended_length_path_re, "", str(path)))
+        if clean_path != path:
+            print(f"cleaned windows extended length path indicator: {path} -> {clean_path}")
+        return clean_path
+    return path
+
+
 def is_relative_to(my: pathlib.Path, *other) -> bool:
     """Return True when path is relative to other path, otherwise False."""
     base = canonical_path(*other)
@@ -342,6 +352,8 @@ def is_relative_to(my: pathlib.Path, *other) -> bool:
         # resolve symlinks to catch Zip-Slip style vulnerability
         my_resolved = my.resolve(strict=False)
         base_resolved = base.resolve(strict=False)
+        my_resolved = clean_windows_extended_length_path_indicator(my_resolved)
+        base_resolved = clean_windows_extended_length_path_indicator(base_resolved)
         if my_resolved == base_resolved:
             # don't allow paths to be equal to base
             return False


### PR DESCRIPTION
when checking relative paths.

## Pull request type

- Bug fix

## Which ticket is resolved?

- issue #714 

## What does this PR change?

This PR removes any windows extended length path indicators when comparing paths to check if one is relative to the other.  The extended length path indicator may or may not be returned by resolve.  If one path has the indicator and one does not then the test for relative_to will always fail.

## Other information

The print statement needs to be removed, but is useful to verify the fix is sometimes used.
In testing I saw 8 instances when the fix was required out of 53 trials.  This was on windows 11 pro using python 3.13.11.
