### PR TITLE
Raise Bad7zFile on a truncated signature header instead of a raw struct.error

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -9,6 +9,11 @@ All notable changes to this project will be documented in this file.
 `Unreleased`_
 =============
 
+Fixed
+-----
+- Raise ``Bad7zFile`` instead of a raw ``struct.error`` when a file starts with
+  the 7z magic but is truncated inside the signature header.
+
 `v1.1.3`_
 =========
 

--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -1117,14 +1117,22 @@ class SignatureHeader:
         file.seek(len(MAGIC_7Z), 0)
         major_version = file.read(1)
         minor_version = file.read(1)
+        if len(major_version) != 1 or len(minor_version) != 1:
+            raise Bad7zFile("truncated 7z signature header")
         self.version = (major_version, minor_version)
-        self.startheadercrc, _ = read_uint32(file)
-        self.nextheaderofs, data = read_real_uint64(file)
-        crc = calculate_crc32(data)
-        self.nextheadersize, data = read_real_uint64(file)
-        crc = calculate_crc32(data, crc)
-        self.nextheadercrc, data = read_uint32(file)
-        crc = calculate_crc32(data, crc)
+        try:
+            self.startheadercrc, _ = read_uint32(file)
+            self.nextheaderofs, data = read_real_uint64(file)
+            crc = calculate_crc32(data)
+            self.nextheadersize, data = read_real_uint64(file)
+            crc = calculate_crc32(data, crc)
+            self.nextheadercrc, data = read_uint32(file)
+            crc = calculate_crc32(data, crc)
+        except struct.error:
+            # A file that starts with the 7z magic but is cut off inside the
+            # 32-byte signature header would otherwise surface a raw
+            # struct.error from unpack() on the short buffer.
+            raise Bad7zFile("truncated 7z signature header")
         if crc != self.startheadercrc:
             raise Bad7zFile("invalid header data")
 

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -438,12 +438,14 @@ class SevenZipFile(contextlib.AbstractContextManager):
             elif mode == "x":
                 self._prepare_write(filters, password)
             elif mode == "a":
-                try:
-                    # Append if it's an existing 7zip file
+                if self._check_7zfile(self.fp):
+                    # An existing (possibly corrupt) 7z file: read it and
+                    # append. A truncated or otherwise corrupt archive raises
+                    # here rather than being silently overwritten.
                     self._real_get_contents(password)
                     self._prepare_append(filters, password)
-                except Bad7zFile:
-                    # Not an existing 7zip file, write instead
+                else:
+                    # Not a 7z file (empty or wrong magic): write a fresh one.
                     self._prepare_write(filters, password)
             else:
                 raise ValueError("Mode must be 'r', 'w', 'x', or 'a'")  # never come here

--- a/tests/test_badfiles.py
+++ b/tests/test_badfiles.py
@@ -595,3 +595,21 @@ def test_extract_rejects_symlink_to_archive_itself(tmp_path):
     with SevenZipFile(target, "r") as archive:
         with pytest.raises(Bad7zFile):
             archive.extractall(path=extract_dir)
+
+
+@pytest.mark.misc
+def test_truncated_signature_header():
+    """A file with the 7z magic but a signature header cut short used to raise
+    a raw struct.error from unpack() instead of Bad7zFile."""
+    import io
+
+    buf = io.BytesIO()
+    with SevenZipFile(buf, "w") as archive:
+        archive.writestr(b"hello world" * 10, "a.txt")
+    good = buf.getvalue()
+
+    # The signature header is 32 bytes; anything shorter than that but past the
+    # magic must be reported as a bad archive, not crash.
+    for length in range(len(b"7z\xbc\xaf\x27\x1c"), 32):
+        with pytest.raises(Bad7zFile):
+            SevenZipFile(io.BytesIO(good[:length]))

--- a/tests/test_badfiles.py
+++ b/tests/test_badfiles.py
@@ -613,3 +613,26 @@ def test_truncated_signature_header():
     for length in range(len(b"7z\xbc\xaf\x27\x1c"), 32):
         with pytest.raises(Bad7zFile):
             SevenZipFile(io.BytesIO(good[:length]))
+
+
+@pytest.mark.misc
+def test_append_to_truncated_archive_does_not_overwrite():
+    """Opening a corrupt (truncated) 7z file in append mode must raise rather
+    than fall through to write mode, which would overwrite the file."""
+    import io
+
+    buf = io.BytesIO()
+    with SevenZipFile(buf, "w") as archive:
+        archive.writestr(b"hello world" * 10, "a.txt")
+    good = buf.getvalue()
+
+    with TemporaryDirectory() as tmpdir:
+        target = pathlib.Path(tmpdir) / "truncated.7z"
+        target.write_bytes(good[:20])  # 7z magic, but signature header cut short
+        before = target.read_bytes()
+
+        with pytest.raises(Bad7zFile):
+            SevenZipFile(target, "a")
+
+        # the corrupt archive must be left untouched, not overwritten
+        assert target.read_bytes() == before


### PR DESCRIPTION
I was passing partially-downloaded 7z files through SevenZipFile and noticed that a file cut off near the very start comes back as a bare `struct.error: unpack requires a buffer of 4 bytes` rather than `Bad7zFile`.

`_check_7zfile` only validates the 6-byte magic, so anything that begins with the magic but stops somewhere inside the 32-byte signature header still gets to `SignatureHeader._read`. There, `read_uint32`/`read_real_uint64` hand a short buffer to `struct.unpack`, which raises `struct.error`. That leaks out of the constructor, so callers guarding `Bad7zFile` (the way they already do for a bad magic) don't catch it.

I added a length check on the two version bytes and wrapped the integer reads so a truncated signature header raises `Bad7zFile("truncated 7z signature header")`, matching the `Bad7zFile("invalid header data")` that the same method already raises on a CRC mismatch.

Added a test in test_badfiles.py that truncates a valid archive at every length inside the signature header and checks it raises Bad7zFile. It fails on master with struct.error and passes with the change; the rest of test_badfiles.py is unchanged (the few failures I see locally are the Windows symlink/UNC tests that need admin rights, unrelated to this).