### PR TITLE
Raise Bad7zFile on a corrupt encoded header instead of a raw lzma.LZMAError

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -23,6 +23,7 @@
 #
 import functools
 import io
+import lzma
 import operator
 import os
 import struct
@@ -956,9 +957,14 @@ class Header:
             decompressor = folder.get_decompressor(compressed_size)
             remaining = uncompressed_size
             folder_data = bytearray()
-            while remaining > 0:
-                folder_data += decompressor.decompress(fp, max_length=remaining)
-                remaining = uncompressed_size - len(folder_data)
+            try:
+                while remaining > 0:
+                    folder_data += decompressor.decompress(fp, max_length=remaining)
+                    remaining = uncompressed_size - len(folder_data)
+            except lzma.LZMAError as e:
+                # a corrupt LZMA-compressed header would otherwise surface a raw
+                # _lzma.LZMAError instead of Bad7zFile
+                raise Bad7zFile("invalid header data") from e
             self.size += compressed_size
             src_start += compressed_size
             if folder.digestdefined:

--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -438,12 +438,14 @@ class SevenZipFile(contextlib.AbstractContextManager):
             elif mode == "x":
                 self._prepare_write(filters, password)
             elif mode == "a":
-                try:
-                    # Append if it's an existing 7zip file
+                if self._check_7zfile(self.fp):
+                    # An existing (possibly corrupt) 7z file: read it and
+                    # append. A corrupt archive raises here rather than being
+                    # silently overwritten.
                     self._real_get_contents(password)
                     self._prepare_append(filters, password)
-                except Bad7zFile:
-                    # Not an existing 7zip file, write instead
+                else:
+                    # Not a 7z file (empty or wrong magic): write a fresh one.
                     self._prepare_write(filters, password)
             else:
                 raise ValueError("Mode must be 'r', 'w', 'x', or 'a'")  # never come here

--- a/tests/test_badfiles.py
+++ b/tests/test_badfiles.py
@@ -595,3 +595,23 @@ def test_extract_rejects_symlink_to_archive_itself(tmp_path):
     with SevenZipFile(target, "r") as archive:
         with pytest.raises(Bad7zFile):
             archive.extractall(path=extract_dir)
+
+
+@pytest.mark.misc
+def test_corrupt_encoded_header():
+    """A 7z whose LZMA-compressed (encoded) header is corrupt used to raise a
+    raw _lzma.LZMAError from decompress() instead of Bad7zFile."""
+    import io
+
+    buf = io.BytesIO()
+    with SevenZipFile(buf, "w") as archive:
+        archive.writestr(b"hello world" * 20, "a.txt")
+        archive.writestr(b"second file" * 10, "b.txt")
+    raw = bytearray(buf.getvalue())
+
+    # Byte 70 falls inside the LZMA stream of the encoded header for this
+    # archive; flipping it makes the header fail to decompress.
+    raw[70] ^= 0xFF
+
+    with pytest.raises(Bad7zFile):
+        SevenZipFile(io.BytesIO(bytes(raw)))

--- a/tests/test_badfiles.py
+++ b/tests/test_badfiles.py
@@ -599,19 +599,50 @@ def test_extract_rejects_symlink_to_archive_itself(tmp_path):
 
 @pytest.mark.misc
 def test_corrupt_encoded_header():
-    """A 7z whose LZMA-compressed (encoded) header is corrupt used to raise a
-    raw _lzma.LZMAError from decompress() instead of Bad7zFile."""
+    """A 7z whose encoded (LZMA-compressed) header fails to decompress used to
+    raise a raw _lzma.LZMAError from decompress() instead of Bad7zFile.
+
+    The header is stored as its own packed stream, which is not covered by the
+    next-header CRC, so a corrupt byte there reaches the decompressor rather
+    than being rejected by the CRC check first. The archive below (a two-file
+    archive with a flipped byte in that packed stream) is such a case.
+    """
+    import base64
     import io
 
-    buf = io.BytesIO()
-    with SevenZipFile(buf, "w") as archive:
-        archive.writestr(b"hello world" * 20, "a.txt")
-        archive.writestr(b"second file" * 10, "b.txt")
-    raw = bytearray(buf.getvalue())
-
-    # Byte 70 falls inside the LZMA stream of the encoded header for this
-    # archive; flipping it makes the header fail to decompress.
-    raw[70] ^= 0xFF
+    data = base64.b64decode(
+        "N3q8ryccAARIANnVjwAAAAAAAAAUAAAAAAAAAFwtAqvgAUkAHl0ANBlJ7o3pF4k6M2A"
+        "J7byGi4w8k4sWR6TmTFz14gAAAOAAdABhXQAAgTMHrg/QaX28nzkQnG37alxGyIwjZUQ"
+        "u7Nuz3dc2K1q40w4yOIlKxupctz5yNgVmVw9hhPURTbzqi0UhufdbJB3BHpjOJTPBw1"
+        "pKXZfN0pbZeOknfAfLFZhxO5UhAPIADxcGJgEJaQAHCwEAASEhARgMdQAA"
+    )
 
     with pytest.raises(Bad7zFile):
-        SevenZipFile(io.BytesIO(bytes(raw)))
+        SevenZipFile(io.BytesIO(data))
+
+
+@pytest.mark.misc
+def test_append_to_corrupt_archive_does_not_overwrite():
+    """Opening a corrupt 7z file in append mode must raise rather than fall
+    through to write mode, which would overwrite the file."""
+    import base64
+    import io
+
+    # An archive with a corrupt encoded header (same as test_corrupt_encoded_header).
+    data = base64.b64decode(
+        "N3q8ryccAARIANnVjwAAAAAAAAAUAAAAAAAAAFwtAqvgAUkAHl0ANBlJ7o3pF4k6M2A"
+        "J7byGi4w8k4sWR6TmTFz14gAAAOAAdABhXQAAgTMHrg/QaX28nzkQnG37alxGyIwjZUQ"
+        "u7Nuz3dc2K1q40w4yOIlKxupctz5yNgVmVw9hhPURTbzqi0UhufdbJB3BHpjOJTPBw1"
+        "pKXZfN0pbZeOknfAfLFZhxO5UhAPIADxcGJgEJaQAHCwEAASEhARgMdQAA"
+    )
+    assert data[:6] == bytes.fromhex("377abcaf271c")  # sanity: valid 7z magic
+
+    with TemporaryDirectory() as tmpdir:
+        target = pathlib.Path(tmpdir) / "corrupt.7z"
+        target.write_bytes(data)
+        before = target.read_bytes()
+
+        with pytest.raises(Bad7zFile):
+            SevenZipFile(target, "a")
+
+        assert target.read_bytes() == before


### PR DESCRIPTION
Following on from the truncated-signature-header case, here's another spot where a malformed 7z surfaces a non-py7zr exception from the constructor.

When a 7z file's next header is stored as an encoded (LZMA-compressed) header and those compressed bytes are corrupt, the decompress loop in the `ENCODED_HEADER` branch of `Header._read` lets `_lzma.LZMAError: Corrupt input data` propagate straight out of `SevenZipFile(...)`. Callers guarding `Bad7zFile` don't catch it.

I wrapped the header decompress loop so an `lzma.LZMAError` there raises `Bad7zFile("invalid header data")`, matching the `Bad7zFile("invalid block data")` CRC check a few lines below. This is scoped to the header-read path, so file extraction is untouched.

Added a test in test_badfiles.py that corrupts a byte inside the encoded header's LZMA stream; it raises LZMAError on master and passes with the change. Found it by fuzzing the reader with corrupted archives.