### PR TITLE
fix: raise Bad7zFile on a truncated header field instead of struct.error

### DIFF
--- a/py7zr/archiveinfo.py
+++ b/py7zr/archiveinfo.py
@@ -85,6 +85,8 @@ def write_byte(file: BinaryIO | WriteWithCrc, data):
 def read_real_uint64(file: BinaryIO) -> tuple[int, bytes]:
     """read 8 bytes, return unpacked value as a little endian unsigned long long, and raw data."""
     res = file.read(8)
+    if len(res) != 8:
+        raise Bad7zFile("truncated archive: expected 8 bytes for a uint64")
     a = unpack("<Q", res)[0]
     return a, res
 
@@ -92,6 +94,8 @@ def read_real_uint64(file: BinaryIO) -> tuple[int, bytes]:
 def read_uint32(file: BinaryIO) -> tuple[int, bytes]:
     """read 4 bytes, return unpacked value as a little endian unsigned long, and raw data."""
     res = file.read(4)
+    if len(res) != 4:
+        raise Bad7zFile("truncated archive: expected 4 bytes for a uint32")
     a = unpack("<L", res)[0]
     return a, res
 

--- a/tests/test_badfiles.py
+++ b/tests/test_badfiles.py
@@ -1,5 +1,6 @@
 # Security protection test cases
 import ctypes
+import io
 import os
 import pathlib
 import sys
@@ -34,6 +35,16 @@ def test_get_sanitized_output_path_2(tmp_path):
     good_path = "good.sh"
     expected = tmp_path.joinpath(good_path)
     assert expected == get_sanitized_output_path(good_path, tmp_path)
+
+
+@pytest.mark.misc
+def test_truncated_signature_header():
+    # a file with the 7z magic but a signature header truncated before its
+    # uint32/uint64 fields used to raise a bare struct.error instead of Bad7zFile
+    magic = b"7z\xbc\xaf\x27\x1c\x00\x04"
+    for data in (magic, magic + b"\x00" * 10):
+        with pytest.raises(Bad7zFile):
+            SevenZipFile(io.BytesIO(data), "r")
 
 
 @pytest.mark.security


### PR DESCRIPTION
`read_real_uint64` and `read_uint32` unpack whatever `file.read` returns without checking the length, so a 7z file with a valid magic but a header truncated in the middle of a uint field raises a bare `struct.error` (e.g. `unpack requires a buffer of 8 bytes`) instead of `Bad7zFile`. A short read there always means a truncated or corrupt archive, so I raise `Bad7zFile` like the rest of the header parser does. Found it fuzzing truncated archives; the signature header is the first thing hit.