### PR TITLE
Honor dry_run in pack_7zarchive

### DIFF
--- a/py7zr/py7zr.py
+++ b/py7zr/py7zr.py
@@ -1266,6 +1266,10 @@ def pack_7zarchive(base_name, base_dir, owner=None, group=None, dry_run=None, lo
     Function for registering with shutil.register_archive_format().
     """
     target_name = f"{base_name}.7z"
+    if dry_run:
+        if logger is not None:
+            logger.debug("py7zr: creating '%s' from '%s'", target_name, base_dir)
+        return target_name
     with SevenZipFile(target_name, mode="w") as archive:
         archive.writeall(path=base_dir)
     return target_name

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -342,6 +342,24 @@ def test_register_archive_format(tmp_path):
 
 
 @pytest.mark.api
+def test_register_archive_format_dry_run(tmp_path):
+    # shutil.make_archive() documents that "If dry_run is true, no archive is
+    # created, but the operations that would be executed are logged", and its
+    # own zip/tar archivers honor that. pack_7zarchive() must do the same
+    # instead of writing the archive anyway.
+    tmp_path.joinpath("src").mkdir()
+    py7zr.unpack_7zarchive(os.path.join(testdata_path, "test_1.7z"), path=tmp_path.joinpath("src"))
+    #
+    shutil.register_archive_format("7zip", pack_7zarchive, description="7zip archive")
+    target = tmp_path.joinpath("target")
+    result = shutil.make_archive(str(target), "7zip", str(tmp_path.joinpath("src")), dry_run=True)
+    # the reported would-be filename is still returned...
+    assert result == str(target) + ".7z"
+    # ...but nothing is actually written to disk.
+    assert not os.path.exists(result)
+
+
+@pytest.mark.api
 def test_compress_with_simple_filter(tmp_path):
     my_filters = [
         {"id": py7zr.FILTER_LZMA2, "preset": py7zr.PRESET_DEFAULT},


### PR DESCRIPTION
## Summary

`pack_7zarchive()` (the helper meant for `shutil.register_archive_format()`) accepts a `dry_run` keyword argument but never actually looks at it. `shutil.make_archive()` documents that `dry_run=True` should report the archive that would be created without writing anything to disk, and the standard library's own zip/tar archivers behave that way. When py7zr is registered as an archive format, calling `shutil.make_archive(..., dry_run=True)` still creates a full `.7z` file.

This came up in #413, where the reporter noted that `dry_run=True` "seems to be ignored, as py7zr starts right away." The maintainer's reply focused on the `root_dir` part of that issue (which is really `shutil`'s own job, since `make_archive` chdirs into `root_dir` itself before calling the registered packer), but the `dry_run` behavior is a separate, independent bug in `pack_7zarchive` itself and is still present on current `master`.

Reproduction against an unmodified checkout:

```python
import shutil, py7zr, os

shutil.register_archive_format('7zip', py7zr.pack_7zarchive, description='7zip archive')

before = set(os.listdir('.'))
result = shutil.make_archive('out', '7zip', root_dir='srcdir', dry_run=True)
after = set(os.listdir('.'))
print(result)                  # .../out.7z
print(after - before)          # {'out.7z'}  <- created anyway

# for comparison, the builtin zip archiver:
result = shutil.make_archive('out', 'zip', root_dir='srcdir', dry_run=True)
print(set(os.listdir('.')) - before)  # set()  <- nothing written
```

## Fix

`pack_7zarchive()` now returns the target filename immediately (optionally logging it, same as the stdlib archivers do) when `dry_run` is truthy, instead of falling through to actually writing the archive.

## Testing

Added `test_register_archive_format_dry_run` in `tests/test_archive.py`, next to the existing `test_register_archive_format`. It registers the format, calls `shutil.make_archive(..., dry_run=True)`, and asserts the reported filename is returned but nothing is written to disk. I confirmed it fails against unmodified `pack_7zarchive` (assert not True, since the file gets created) and passes with the fix.

Ran the full `tests/test_archive.py` suite locally: 50 passed, plus 2 pre-existing failures (`AttributeError: module 'py7zr' has no attribute 'cli'`) that reproduce identically on unmodified `master` in this environment and are unrelated to this change.